### PR TITLE
chore(tests): add test-safety wrappers, smoke script, and conftest (squashed)

### DIFF
--- a/.github/workflows/manual-smoke.yml
+++ b/.github/workflows/manual-smoke.yml
@@ -1,0 +1,23 @@
+name: Manual Smoke Test
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  smoke:
+    name: Run smoke script (manual)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Run smoke script
+        shell: bash
+        run: |
+          chmod +x ci/smoke.sh || true
+          bash ci/smoke.sh

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,33 @@
+name: Smoke tests (non-E2E)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.11, 3.12]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Create TEST_TMPDIR
+        run: |
+          echo "TEST_TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r doc_processor/requirements.txt
+      - name: Run non-E2E tests
+        working-directory: doc_processor
+        env:
+          TEST_TMPDIR: ${{ env.TEST_TMPDIR }}
+        run: |
+          pytest -q -k "not e2e and not playwright"

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,24 @@
+# Smoke test helper
+
+This repository includes a lightweight smoke script to verify that the non-E2E test subset runs under a test-scoped environment (so test writes are redirected to safe locations).
+
+How to run locally
+
+1. From the repo root, make sure you have Python 3 and virtualenv available.
+2. Run the smoke script (it will create/use `doc_processor/venv`):
+
+```bash
+bash ci/smoke.sh
+```
+
+What it does
+
+- Exports `TEST_TMPDIR` (defaults to `/tmp/python_testing_vibe_tests`).
+- Sources `doc_processor/.env.test` when present.
+- Creates/uses a venv at `doc_processor/venv` and installs `doc_processor/requirements.txt` (or at least `pytest`).
+- Runs `pytest -q -k "not e2e and not playwright"`.
+
+Notes
+
+- The script is intentionally lightweight and intended for local developer runs. A manual GitHub Actions workflow is included to allow maintainers to run the same check on-demand.
+- If you want an always-on CI check, we can add a constrained workflow with path filters; tell me and I will add one.

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight smoke script for local verification of test-safety.
+# - Exports TEST_TMPDIR
+# - Sources doc_processor/.env.test if present
+# - Creates/uses venv at doc_processor/venv
+# - Installs minimal deps and runs pytest subset
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_TMPDIR="${TEST_TMPDIR:-/tmp/python_testing_vibe_tests}"
+export TEST_TMPDIR
+
+echo "[smoke] ROOT_DIR=$ROOT_DIR"
+echo "[smoke] TEST_TMPDIR=$TEST_TMPDIR"
+
+if [ -f "$ROOT_DIR/doc_processor/.env.test" ]; then
+  echo "[smoke] sourcing doc_processor/.env.test"
+  # export variables from .env.test into the environment
+  set -a
+  # shellcheck disable=SC1090
+  source "$ROOT_DIR/doc_processor/.env.test"
+  set +a
+fi
+
+VENV_DIR="$ROOT_DIR/doc_processor/venv"
+PYTHON="$VENV_DIR/bin/python"
+PIP="$VENV_DIR/bin/pip"
+
+if [ ! -x "$PYTHON" ]; then
+  echo "[smoke] creating venv at $VENV_DIR"
+  python3 -m venv "$VENV_DIR"
+fi
+
+echo "[smoke] activating venv"
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+# Ensure pytest is available; install minimal requirements if provided
+if [ -f "$ROOT_DIR/doc_processor/requirements.txt" ]; then
+  echo "[smoke] installing requirements from doc_processor/requirements.txt"
+  "$PIP" install --upgrade pip
+  "$PIP" install -r "$ROOT_DIR/doc_processor/requirements.txt"
+else
+  echo "[smoke] requirements.txt not found, ensuring pytest is installed"
+  "$PIP" install --upgrade pip
+  "$PIP" install pytest
+fi
+
+echo "[smoke] running pytest (non-E2E subset)"
+pytest -q -k "not e2e and not playwright"
+
+echo "[smoke] done"

--- a/dev_tools/cleanup_test_artifacts.py
+++ b/dev_tools/cleanup_test_artifacts.py
@@ -55,10 +55,14 @@ def load_env_paths() -> dict:
 def _select_tmp_dir() -> str:
     """Select a temporary directory: TEST_TMPDIR -> TMPDIR -> system tempdir -> cwd."""
     try:
-        import tempfile
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+        from doc_processor.utils.path_utils import select_tmp_dir
+        return select_tmp_dir()
     except Exception:
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
+        try:
+            import tempfile
+            return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+        except Exception:
+            return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
 
 
 def find_candidates(env_paths: dict, allow_tmp: bool=False) -> list[Path]:

--- a/doc_processor/app_monolithic_backup.py
+++ b/doc_processor/app_monolithic_backup.py
@@ -150,16 +150,15 @@ sys.excepthook = log_uncaught_exceptions
 import logging
 
 
-def _select_tmp_dir() -> str:
-    """Select a temporary directory with test-friendly precedence.
-
-    Precedence: TEST_TMPDIR -> TMPDIR -> system tempfile.gettempdir() -> cwd
-    """
-    try:
-        import tempfile as _temp
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or _temp.gettempdir()
-    except Exception:
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir  # type: ignore
+except Exception:
+    def select_tmp_dir() -> str:
+        try:
+            import tempfile
+            return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+        except Exception:
+            return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
 
 # Third-party imports
 from flask import (

--- a/doc_processor/conftest.py
+++ b/doc_processor/conftest.py
@@ -131,6 +131,16 @@ def _enforce_test_environment(tmp_path_factory):
     os.environ.setdefault('OLLAMA_NUM_GPU', '0')
     # Also clear CUDA_VISIBLE_DEVICES for safety
     os.environ.setdefault('CUDA_VISIBLE_DEVICES', '')
+    # Provide a stable test-scoped temp dir for any scripts that honor TEST_TMPDIR
+    # Prefer an explicit tmp in the test workspace to avoid cross-user collisions.
+    test_tmp = os.path.join(str(tempdir), 'test_tmp')
+    os.makedirs(test_tmp, exist_ok=True)
+    os.environ.setdefault('TEST_TMPDIR', test_tmp)
+    # For some scripts we also set common destination overrides if not already set
+    os.environ.setdefault('FILE_UTILS_DEST', test_tmp)
+    os.environ.setdefault('FILING_CABINET_DIR', os.path.join(test_tmp, 'filing_cabinet'))
+    os.environ.setdefault('PROCESSED_DIR', os.path.join(test_tmp, 'processed'))
+    os.environ.setdefault('EXPORT_DIR', os.path.join(test_tmp, 'exports'))
     yield
 
 

--- a/doc_processor/routes/admin.py
+++ b/doc_processor/routes/admin.py
@@ -31,12 +31,16 @@ logger = logging.getLogger(__name__)
 
 
 def _select_tmp_dir() -> str:
-    """Select a temporary directory: TEST_TMPDIR -> TMPDIR -> system tempdir -> cwd."""
     try:
-        import tempfile
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+        from doc_processor.utils.path_utils import select_tmp_dir
     except Exception:
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
+        def select_tmp_dir() -> str:
+            try:
+                import tempfile
+                return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+            except Exception:
+                return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
+    return select_tmp_dir()
 
 @bp.route('/db_diagnostics')
 def db_diagnostics():

--- a/doc_processor/routes/batch.py
+++ b/doc_processor/routes/batch.py
@@ -74,12 +74,16 @@ def _start_smart_token_cleanup_thread():
 
 
 def _select_tmp_dir() -> str:
-    """Select a temporary directory: TEST_TMPDIR -> TMPDIR -> system tempdir -> cwd."""
     try:
-        import tempfile
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+        from doc_processor.utils.path_utils import select_tmp_dir
     except Exception:
-        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
+        def select_tmp_dir() -> str:
+            try:
+                import tempfile
+                return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+            except Exception:
+                return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
+    return select_tmp_dir()
 
 
 def _load_cached_intake_analyses(intake_dir: str) -> dict:

--- a/doc_processor/utils/path_utils.py
+++ b/doc_processor/utils/path_utils.py
@@ -1,0 +1,79 @@
+"""Path utilities for test-friendly temporary and export directory resolution.
+
+Provides a single canonical implementation for selecting temporary
+directories and resolving the filing cabinet/export locations with the
+precedence used across the codebase:
+
+  1. app_config setting (when present)
+  2. explicit environment variable (EXPORT_DIR / FILING_CABINET_DIR)
+  3. TEST_TMPDIR
+  4. TMPDIR
+  5. tempfile.gettempdir()
+  6. os.getcwd() (last resort)
+
+These helpers make it safe to run tests in CI by allowing tests to set
+`TEST_TMPDIR` or configure `app_config` to a tmp path while preserving
+production behavior when real paths are configured.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Optional
+
+try:
+    # app_config is available when running the app via package import
+    from ..config_manager import app_config
+except Exception:
+    app_config = None  # type: ignore
+
+
+def select_tmp_dir() -> str:
+    """Select a temporary directory with test-friendly precedence.
+
+    Precedence: TEST_TMPDIR -> TMPDIR -> system tempfile.gettempdir() -> cwd
+    """
+    try:
+        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+    except Exception:
+        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or os.getcwd()
+
+
+def ensure_dir(path: str) -> str:
+    """Ensure directory exists (best-effort). Returns absolute path.
+
+    If creation fails, returns the original absolute path (caller may
+    choose to fallback further).
+    """
+    abspath = os.path.abspath(path)
+    try:
+        os.makedirs(abspath, exist_ok=True)
+    except Exception:
+        # If we cannot create, just return the absolute path; callers
+        # should handle fallbacks where appropriate.
+        return abspath
+    return abspath
+
+
+def resolve_filing_cabinet_dir(category: Optional[str] = None) -> str:
+    """Resolve a safe filing cabinet directory for exports/sidecars.
+
+    Precedence: app_config.FILING_CABINET_DIR -> FILING_CABINET_DIR env -> TEST_TMPDIR -> TMPDIR -> system tempdir -> cwd
+    If category is provided, returns the category subdirectory (sanitized with spaces replaced by '_') and ensures it exists.
+    """
+    base = None
+    try:
+        if app_config is not None:
+            base = getattr(app_config, 'FILING_CABINET_DIR', None)
+    except Exception:
+        base = None
+
+    base = base or os.environ.get('FILING_CABINET_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+    if category:
+        safe_category = category.replace(' ', '_')
+        path = os.path.join(base, safe_category)
+    else:
+        path = base
+
+    return ensure_dir(path)

--- a/docs/dry_run_patches/0001_gamelist_editor_safe_output.patch
+++ b/docs/dry_run_patches/0001_gamelist_editor_safe_output.patch
@@ -1,0 +1,36 @@
+*** Dry-run patch for tools/gamelist_editor/gamelist_xml_editor.py
+- Goal: redirect new gamelist output to a configurable/test-safe location.
+- Plan: prefer explicit env var GAMELIST_OUTPUT_DIR, then select_tmp_dir(), then original gamelist_dir.
+- This is a dry-run file; it does not modify source.
+
+Replacement guidance (conceptual):
+
+Locate the block:
+    safe_output_base = os.environ.get('GAMELIST_OUTPUT_DIR') or gamelist_dir
+    new_gamelist_output_path = os.path.join(safe_output_base, "gamelist_new.xml")
+
+Replace with (pseudocode):
+    try:
+        from doc_processor.utils.path_utils import select_tmp_dir
+    except Exception:
+        def select_tmp_dir():
+            import tempfile, os
+            return os.getenv('GAMELIST_BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+    # Prefer explicit env var, then select_tmp_dir (which prefers TEST_TMPDIR), then gamelist_dir as last resort
+    safe_output_base = os.environ.get('GAMELIST_OUTPUT_DIR') or select_tmp_dir() or gamelist_dir
+    # Ensure directory exists before writing
+    try:
+        os.makedirs(safe_output_base, exist_ok=True)
+    except Exception:
+        # best-effort: fallback to gamelist_dir
+        safe_output_base = gamelist_dir
+
+    new_gamelist_output_path = os.path.join(safe_output_base, "gamelist_new.xml")
+
+Notes:
+- This keeps existing behavior when GAMELIST_OUTPUT_DIR is set or when select_tmp_dir() fails.
+- It ensures backups and new outputs go to test-scoped temp locations by default in CI (if TEST_TMPDIR is set).
+- Keep messagebox and status strings unchanged; only the output path resolution is modified.
+
+*** End dry-run patch

--- a/docs/dry_run_patches/0002_legacy_gem_safewrap.patch
+++ b/docs/dry_run_patches/0002_legacy_gem_safewrap.patch
@@ -1,0 +1,40 @@
+*** Dry-run patch for Document_Scanner_Ollama_outdated/document_processor_gem.py
+- Goal: show a templated safe-wrap for calls that create directories or write files in legacy scripts.
+- This is a dry-run file; it does not modify source.
+
+Example replacement guidance for patterns like:
+    os.makedirs(destination_dir, exist_ok=True)
+    shutil.copy2(source_pdf_path, original_copy_path)
+
+Replace with:
+    # Safe output resolution: prefer explicit env, then TEST_TMPDIR/TMPDIR, then temp dir, then original destination
+    try:
+        from doc_processor.utils.path_utils import select_tmp_dir
+        safe_base = select_tmp_dir()
+    except Exception:
+        import tempfile
+        safe_base = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+    # If this script intentionally writes into project/archival dirs, prefer explicit ARCHIVE_DIR env first
+    archive_env = os.environ.get('ARCHIVE_DIR')
+    if archive_env:
+        archive_dest = archive_env
+    else:
+        # Map original destination into safe_base to avoid writing into repo tree during tests
+        archive_dest = os.path.join(safe_base, os.path.basename(destination_dir))
+
+    try:
+        os.makedirs(archive_dest, exist_ok=True)
+    except Exception:
+        # best-effort fallback: try original destination (may raise)
+        archive_dest = destination_dir
+        os.makedirs(archive_dest, exist_ok=True)
+
+    # Use archive_dest for subsequent writes/copies
+    shutil.copy2(source_pdf_path, os.path.join(archive_dest, os.path.basename(source_pdf_path)))
+
+Notes:
+- This template preserves behavior when ARCHIVE_DIR env var is provided.
+- Use this approach for legacy scripts where changing logic safely requires mapping to a temporary area in tests.
+
+*** End dry-run patch

--- a/docs/dry_run_patches/0003_gem_gca_safewrap.patch
+++ b/docs/dry_run_patches/0003_gem_gca_safewrap.patch
@@ -1,0 +1,30 @@
+*** Dry-run patch for Document_Scanner_Ollama_outdated/document_processor_gca.py
+- Goal: make legacy GCA script write operations test-safe by mapping archive/cache dirs to a test-scoped base.
+
+Guidance (dry-run; do not modify source):
+
+1) Add import fallback near top if not present:
+    try:
+        from doc_processor.utils.path_utils import select_tmp_dir
+    except Exception:
+        import tempfile, os
+        def select_tmp_dir():
+            return os.environ.get('GCA_CACHE_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+2) Replace direct os.makedirs(PATH, exist_ok=True) with mapped destination:
+    safe_base = os.environ.get('ARCHIVE_DIR') or select_tmp_dir()
+    mapped_dest = os.path.join(safe_base, os.path.basename(PATH))
+    try:
+        os.makedirs(mapped_dest, exist_ok=True)
+    except Exception:
+        mapped_dest = PATH
+        os.makedirs(mapped_dest, exist_ok=True)
+    # use mapped_dest for subsequent writes
+
+3) For file copies/moves and file writes, prefer mapping to mapped_dest. If the script expects a specific layout under ARCHIVE, preserve subpath mapping (e.g., join with original relative path).
+
+Notes:
+- Preserve behavior if explicit ARCHIVE_DIR or GCA_CACHE_DIR env var is set.
+- This patch is intentionally conservative and only remaps top-level destinations to avoid writing into repo tree during tests.
+
+*** End dry-run patch

--- a/docs/dry_run_patches/0004_clean_workflows_review.patch
+++ b/docs/dry_run_patches/0004_clean_workflows_review.patch
@@ -1,0 +1,21 @@
+*** Dry-run patch for tools/clean_workflows.py (review)
+- Goal: ensure clean_workflows writes to configurable output and is test-safe.
+
+Existing behavior: writes/moves files under '.github/workflows' and archive to '.github/workflows_archived'.
+
+Dry-run recommended edits (already applied to source earlier):
+- Use env var CLEAN_WORKFLOWS_OUT_DIR to override output.
+- Default to os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') when not set, falling back to the repo path '.github/workflows'.
+- Add CLI flag --out to override.
+
+Suggested safe code snippet:
+    _env_out = os.environ.get('CLEAN_WORKFLOWS_OUT_DIR')
+    _test_tmp = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR')
+    OUT_DIR = _env_out or (_test_tmp and os.path.join(_test_tmp, 'workflows')) or '.github/workflows'
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+Notes:
+- When running in CI, set CLEAN_WORKFLOWS_OUT_DIR or TEST_TMPDIR to avoid modifying .github in repo.
+- This file was already patched in an earlier step; include in dry-run review artifacts.
+
+*** End dry-run patch

--- a/docs/dry_run_patches/0005_sdcard_imager_log.patch
+++ b/docs/dry_run_patches/0005_sdcard_imager_log.patch
@@ -1,0 +1,19 @@
+*** Dry-run patch for tools/sdcard_imager/SDCardImager.py (review)
+- Goal: ensure log file path is configurable/test-safe and log dir is created before writing.
+
+Existing behavior: used a repo-local path for error log. Earlier we updated it to prefer env SDCARD_IMAGER_LOG or LOG_FILE_PATH then TEST_TMPDIR/TMPDIR; include as a dry-run review artifact.
+
+Suggested snippet (already applied):
+    _env_log = os.environ.get('SDCARD_IMAGER_LOG') or os.environ.get('LOG_FILE_PATH')
+    _test_tmp = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR')
+    LOG_FILE_PATH = _env_log or (os.path.join(_test_tmp, 'sd_card_imager_error.log') if _test_tmp else os.path.join(os.path.dirname(__file__), 'sd_card_imager_error.log'))
+    # ensure log dir
+    try:
+        os.makedirs(os.path.dirname(LOG_FILE_PATH), exist_ok=True)
+    except Exception:
+        pass
+
+Notes:
+- This was already patched. Keep as-is.
+
+*** End dry-run patch

--- a/docs/dry_run_patches/0006_download_manager.patch
+++ b/docs/dry_run_patches/0006_download_manager.patch
@@ -1,0 +1,13 @@
+*** Dry-run patch for tools/download_manager/download_manager.py
+- Goal: ensure download manager uses `select_tmp_dir()` (already present) and document fallback behavior for clarity.
+
+Note: `download_manager.py` already imports `select_tmp_dir()` from `doc_processor.utils.path_utils`.
+
+Suggested documentation snippet (dry-run):
+    # Prefer explicit env var (DOWNLOAD_DIR) if provided, otherwise use select_tmp_dir()
+    download_location = os.environ.get('DOWNLOAD_DIR') or select_tmp_dir()
+    os.makedirs(download_location, exist_ok=True)
+
+Keep behavior unchanged; just document and ensure makedirs.
+
+*** End dry-run patch

--- a/docs/dry_run_patches/0007_dev_tools_safe_backup.patch
+++ b/docs/dry_run_patches/0007_dev_tools_safe_backup.patch
@@ -1,0 +1,25 @@
+*** Dry-run patch for dev_tools scripts (generic)
+- Goal: template for dev_tools scripts that perform backups or create files; redirect outputs to TEST_TMPDIR by default.
+
+Template (dry-run, to be applied per-file):
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    import tempfile, os
+    def select_tmp_dir():
+        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Prefer explicit env var BACKUP_DIR, then select_tmp_dir(), then original fallback
+backup_base = os.environ.get('BACKUP_DIR') or select_tmp_dir()
+try:
+    os.makedirs(backup_base, exist_ok=True)
+except Exception:
+    backup_base = original_backup_dir  # fallback to original if creation fails
+
+# Use backup_base for subsequent writes
+
+Notes:
+- Apply to dev_tools/* scripts that currently write into repo tree (e.g., dev_tools/database_setup.py, dev_tools/retention_and_rotate.py)
+
+*** End dry-run patch

--- a/docs/dry_run_patches/applied/SDCardImager_patched.py
+++ b/docs/dry_run_patches/applied/SDCardImager_patched.py
@@ -1,0 +1,121 @@
+"""
+Dry-run wrapper for tools/sdcard_imager/SDCardImager.py
+
+This wrapper ensures the log file is redirected to a test-safe location (prefer existing env, then TEST_TMPDIR, then select_tmp_dir())
+before importing the original module so its module-level LOG_FILE_PATH picks up the override.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# Prefer explicit overrides; otherwise put logs under TEST_TMPDIR or select_tmp_dir()
+candidate = os.environ.get('SDCARD_IMAGER_LOG') or os.environ.get('LOG_FILE_PATH')
+if not candidate:
+    candidate = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+
+# Set both names so the module picks either env it checks
+os.environ.setdefault('SDCARD_IMAGER_LOG', candidate)
+os.environ.setdefault('LOG_FILE_PATH', candidate)
+
+def get_SDCardImager():
+    """Lazy import helper that returns the SDCardImager class from the original module.
+
+    Use this to avoid import-time side-effects and static analysis warnings in non-Windows test environments.
+    """
+    from tools.sdcard_imager.SDCardImager import SDCardImager  # type: ignore
+    return SDCardImager
+
+__all__ = ['get_SDCardImager']
+"""Dry-run patched copy of tools/sdcard_imager/SDCardImager.py
+This copy prefers TEST_TMPDIR/select_tmp_dir for log file paths and is non-destructive (for review).
+"""
+import os
+import sys
+import threading
+import traceback
+import datetime
+import time
+import ctypes
+import logging
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# Determine log path with env override or test-safe fallback
+_env_log = os.environ.get('SDCARD_IMAGER_LOG') or os.environ.get('LOG_FILE_PATH')
+_test_tmp = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR')
+if _env_log:
+    LOG_FILE_PATH = _env_log
+elif _test_tmp:
+    LOG_FILE_PATH = os.path.join(_test_tmp, 'sd_card_imager_error.log')
+else:
+    LOG_FILE_PATH = os.path.join(select_tmp_dir(), 'sd_card_imager_error.log')
+
+os.makedirs(os.path.dirname(LOG_FILE_PATH), exist_ok=True)
+
+def log_message(message, level="INFO"):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    log_entry = f"[{timestamp}] [{level}] {message}\n"
+    try:
+        with open(LOG_FILE_PATH, "a") as log_f:
+            log_f.write(log_entry)
+    except Exception:
+        print(log_entry)
+
+def log_exception(exc_type, exc_value, exc_traceback):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    error_message = f"[{timestamp}] [ERROR] Unhandled Exception:\n"
+    error_message += "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+    try:
+        with open(LOG_FILE_PATH, "a") as log_f:
+            log_f.write(error_message)
+    except Exception:
+        print(error_message)
+
+sys.excepthook = log_exception
+
+def is_admin():
+    try:
+        is_user_admin = ctypes.windll.shell32.IsUserAnAdmin()
+        log_message(f"IsUserAnAdmin() returned: {is_user_admin}", "DEBUG")
+        return is_user_admin
+    except Exception as e:
+        log_message(f"Error checking admin status: {e}", "ERROR")
+        return False
+
+def main():
+    # Non-GUI test-safe entrypoint that just writes an initialization log.
+    log_message("SDCardImager (dry-run patched) initialized.", "INFO")
+
+if __name__ == '__main__':
+    main()
+# Dry-run patched copy of tools/sdcard_imager/SDCardImager.py
+# Purpose: demonstrate LOG_FILE_PATH resolution already applied earlier
+import os
+import tempfile
+_env_log = os.environ.get('SDCARD_IMAGER_LOG') or os.environ.get('LOG_FILE_PATH')
+_test_tmp = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR')
+if _env_log:
+    LOG_FILE_PATH = _env_log
+elif _test_tmp:
+    LOG_FILE_PATH = os.path.join(_test_tmp, 'sd_card_imager_error.log')
+else:
+    LOG_FILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sd_card_imager_error.log")
+
+try:
+    os.makedirs(os.path.dirname(LOG_FILE_PATH), exist_ok=True)
+except Exception:
+    pass
+
+# rest of file omitted for dry-run

--- a/docs/dry_run_patches/applied/add_document_tags_table_patched.py
+++ b/docs/dry_run_patches/applied/add_document_tags_table_patched.py
@@ -1,0 +1,31 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/add_document_tags_table.py
+
+Sets `DATABASE_PATH` and `DB_BACKUP_DIR` to test-scoped locations (prefer
+`TEST_TMPDIR`) before importing the original script to avoid touching real DBs.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir, ensure_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+    def ensure_dir(p: str):
+        os.makedirs(p, exist_ok=True)
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+ensure_dir(base)
+
+# Prefer explicit DATABASE_PATH if the user set it, otherwise route to test tmp
+if 'DATABASE_PATH' not in os.environ:
+    os.environ['DATABASE_PATH'] = os.path.join(base, 'documents_test.db')
+
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+
+from doc_processor.dev_tools.add_document_tags_table import main, upgrade_database  # type: ignore
+
+__all__ = ['main', 'upgrade_database']

--- a/docs/dry_run_patches/applied/add_single_document_columns_patched.py
+++ b/docs/dry_run_patches/applied/add_single_document_columns_patched.py
@@ -1,0 +1,44 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/add_single_document_columns.py`.
+
+Sets test-scoped DB paths before importing and re-exports upgrade helpers.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('DATABASE_PATH', str(Path(base) / 'documents_test.db'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'add_single_document_columns.log'))
+
+try:
+    from doc_processor.dev_tools import add_single_document_columns as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'add_single_document_columns.py'
+    spec = importlib.util.spec_from_file_location('add_single_document_columns', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load add_single_document_columns module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'run_migrations', None)
+if _tmp is not None:
+    run_migrations = _tmp
+    __all__.append('run_migrations')

--- a/docs/dry_run_patches/applied/add_single_documents_table_patched.py
+++ b/docs/dry_run_patches/applied/add_single_documents_table_patched.py
@@ -1,0 +1,31 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/add_single_documents_table.py
+
+Sets `DATABASE_PATH` and `DB_BACKUP_DIR` to test-scoped locations before
+importing the original script to avoid modifying real DBs during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir, ensure_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+    def ensure_dir(p: str):
+        os.makedirs(p, exist_ok=True)
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+ensure_dir(base)
+
+# If DATABASE_PATH is not explicitly set, create a test DB under TEST_TMPDIR
+if 'DATABASE_PATH' not in os.environ:
+    os.environ['DATABASE_PATH'] = os.path.join(base, 'documents_single_test.db')
+
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+
+from doc_processor.dev_tools.add_single_documents_table import main, upgrade_database  # type: ignore
+
+__all__ = ['main', 'upgrade_database']

--- a/docs/dry_run_patches/applied/admin_patched.py
+++ b/docs/dry_run_patches/applied/admin_patched.py
@@ -1,0 +1,30 @@
+"""
+Dry-run wrapper for `doc_processor/routes/admin.py`.
+
+Sets test-scoped `LOG_FILE_PATH`, `CACHE_DIR`, and test tmp fallbacks before importing
+the admin blueprint. Re-exports `bp`.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+
+# Safe defaults
+os.environ.setdefault('LOG_FILE_PATH', os.path.join(base, 'logs', 'app.log'))
+os.environ.setdefault('CACHE_DIR', os.path.join(base, 'analysis_cache'))
+os.environ.setdefault('INTAKE_DIR', os.path.join(base, 'intake'))
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+
+from doc_processor.routes.admin import bp as bp  # type: ignore
+
+__all__ = ['bp']
+

--- a/docs/dry_run_patches/applied/app_monolithic_backup_patched.py
+++ b/docs/dry_run_patches/applied/app_monolithic_backup_patched.py
@@ -1,0 +1,15 @@
+# Dry-run patched snippet for archive/app_backups/app_monolithic_backup.py
+# Purpose: ensure LOG_DIR and backup paths prefer env/test tmp
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+LOG_DIR = os.environ.get('LOG_DIR') or select_tmp_dir()
+try:
+    os.makedirs(LOG_DIR, exist_ok=True)
+except Exception:
+    pass

--- a/docs/dry_run_patches/applied/app_original_backup_patched.py
+++ b/docs/dry_run_patches/applied/app_original_backup_patched.py
@@ -1,0 +1,32 @@
+"""
+Dry-run wrapper for `doc_processor/app_original_backup.py`.
+
+This sets test-scoped locations for logs, cache, and backups before importing the
+original module so import-time file operations use safe paths during tests/CI.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+
+# Test-scoped defaults
+os.environ.setdefault('LOG_FILE_PATH', os.path.join(base, 'logs', 'app_original_backup.log'))
+os.environ.setdefault('CACHE_DIR', os.path.join(base, 'cache'))
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+os.environ.setdefault('ARCHIVE_DIR', os.path.join(base, 'archive'))
+
+# Import original module after env is prepared
+from doc_processor import app_original_backup as original  # type: ignore
+
+# Re-export commonly used entry points (if present)
+main = getattr(original, 'main', None)
+__all__ = ['original', 'main']

--- a/docs/dry_run_patches/applied/app_patched.py
+++ b/docs/dry_run_patches/applied/app_patched.py
@@ -1,0 +1,19 @@
+# Dry-run patched snippet for doc_processor/app.py
+# Purpose: ensure log_dir uses app_config or TEST_TMPDIR and is created safely
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('LOG_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example usage:
+log_dir = getattr(__import__('doc_processor.config_manager', fromlist=['app_config']).app_config, 'LOG_DIR', None)
+if not log_dir:
+    log_dir = select_tmp_dir()
+try:
+    os.makedirs(log_dir, exist_ok=True)
+except Exception:
+    log_dir = os.getcwd()
+

--- a/docs/dry_run_patches/applied/batch_guard_patched.py
+++ b/docs/dry_run_patches/applied/batch_guard_patched.py
@@ -1,0 +1,62 @@
+"""
+Dry-run wrapper for `doc_processor/batch_guard.py` (or related batch-guard service).
+
+Pre-sets test-safe paths before importing the original module, then re-exports commonly used symbols.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'batch_guard.log'))
+
+try:
+    from doc_processor import batch_guard as _original
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'batch_guard.py'
+    spec = importlib.util.spec_from_file_location('batch_guard', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load batch_guard module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'BatchGuard', None)
+if _tmp is not None:
+    BatchGuard = _tmp
+    __all__.append('BatchGuard')
+_tmp = getattr(_original, 'guard_batch', None)
+if _tmp is not None:
+    guard_batch = _tmp
+    __all__.append('guard_batch')
+# Dry-run patched snippet for doc_processor/batch_guard.py
+# Purpose: ensure retention_root and dest_dir prefer env/app_config or TEST_TMPDIR and are created safely
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('RETENTION_ROOT') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example usage:
+retention_root = os.environ.get('RETENTION_ROOT') or select_tmp_dir()
+try:
+    os.makedirs(retention_root, exist_ok=True)
+except Exception:
+    pass
+
+# For dest_dir mapping, use similar pattern

--- a/docs/dry_run_patches/applied/batch_service_patched.py
+++ b/docs/dry_run_patches/applied/batch_service_patched.py
@@ -1,0 +1,83 @@
+"""
+Dry-run wrapper for `doc_processor/services/batch_service.py`.
+
+Sets test-safe defaults for DB_BACKUP_DIR, PROCESSED_DIR, FILING_CABINET_DIR and LOG_FILE_PATH
+before importing the real batch service. Re-exports `BatchService` and `process_batch` where present.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+for k in ('DB_BACKUP_DIR', 'PROCESSED_DIR', 'FILING_CABINET_DIR', 'LOG_FILE_PATH'):
+    os.environ.setdefault(k, str(Path(base) / k.lower()))
+
+try:
+    from doc_processor.services import batch_service as _original
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'services' / 'batch_service.py'
+    spec = importlib.util.spec_from_file_location('batch_service', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load batch_service module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+# Re-export common API (guarded, use getattr to keep static-checkers quiet)
+__all__ = []
+_tmp = getattr(_original, 'BatchService', None)
+if _tmp is not None:
+    BatchService = _tmp
+    __all__.append('BatchService')
+_tmp = getattr(_original, 'process_batch', None)
+if _tmp is not None:
+    process_batch = _tmp
+    __all__.append('process_batch')
+"""
+Dry-run wrapper for `doc_processor/services/batch_service.py`.
+Sets safe defaults for DB_BACKUP_DIR, PROCESSED_DIR, FILING_CABINET_DIR, and LOG_FILE_PATH before importing
+and re-exports `BatchService` and `process_batch`.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+for k in ('DB_BACKUP_DIR', 'PROCESSED_DIR', 'FILING_CABINET_DIR', 'LOG_FILE_PATH'):
+    os.environ.setdefault(k, str(Path(base) / k.lower()))
+
+try:
+    from doc_processor.services import batch_service as _original
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'services' / 'batch_service.py'
+    spec = importlib.util.spec_from_file_location('batch_service', str(fallback))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+if hasattr(_original, 'BatchService'):
+    BatchService = _original.BatchService
+if hasattr(_original, 'process_batch'):
+    process_batch = _original.process_batch
+
+__all__ = [name for name in ('BatchService', 'process_batch') if name in globals()]

--- a/docs/dry_run_patches/applied/check_wip_status_patched.py
+++ b/docs/dry_run_patches/applied/check_wip_status_patched.py
@@ -1,0 +1,44 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/check_wip_status.py`.
+
+Sets test-scoped environment variables before importing and re-exports diagnostic functions.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('WIP_DIR', str(Path(base) / 'wip'))
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'check_wip_status.log'))
+
+try:
+    from doc_processor.dev_tools import check_wip_status as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'check_wip_status.py'
+    spec = importlib.util.spec_from_file_location('check_wip_status', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load check_wip_status module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'check', None)
+if _tmp is not None:
+    check = _tmp
+    __all__.append('check')

--- a/docs/dry_run_patches/applied/clean_workflows_patched.py
+++ b/docs/dry_run_patches/applied/clean_workflows_patched.py
@@ -1,0 +1,107 @@
+"""Dry-run patched copy of tools/clean_workflows.py
+Redirects output to test-safe location using select_tmp_dir when available.
+"""
+import re
+import sys
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+ARCHIVE_DIR = Path('.github/workflows_archived')
+_env_out = os.environ.get('CLEAN_WORKFLOWS_OUT_DIR')
+_test_tmp = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR')
+OUT_DIR = Path(_env_out) if _env_out else (Path(_test_tmp) / 'workflows' if _test_tmp else Path(select_tmp_dir()) / 'workflows')
+HEAVY_WORKFLOWS = {'playwright-e2e.yml', 'ci.yml', 'ci-rewrite.yml'}
+
+def strip_code_fence(s: str) -> str:
+    s = re.sub(r"^\s*```(?:yaml)?\n", '', s, flags=re.MULTILINE)
+    s = re.sub(r"\n```\s*$", '', s, flags=re.MULTILINE)
+    return s
+
+def pick_single_document(s: str) -> str:
+    parts = re.split(r'\n-{3,}\n', s)
+    parts = [p.strip() for p in parts if p.strip()]
+    if not parts:
+        return ''
+    for p in parts:
+        if re.match(r'^(name|on):', p):
+            return p + '\n'
+    parts.sort(key=lambda p: len(p.splitlines()), reverse=True)
+    return parts[0] + '\n'
+
+def rewrite_triggers_to_dispatch(content: str, filename: str) -> str:
+    if Path(filename).name in HEAVY_WORKFLOWS:
+        if re.search(r'^\s*on:\s*', content, flags=re.MULTILINE):
+            content = re.sub(r"^\s*on:\s*[\s\S]*?(?=^\S|\Z)", 'on:\n  workflow_dispatch: {}\n', content, flags=re.MULTILINE)
+        else:
+            content = 'on:\n  workflow_dispatch: {}\n\n' + content
+    return content
+
+def clean_one(path: Path) -> str:
+    s = path.read_text(encoding='utf-8')
+    s = strip_code_fence(s)
+    doc = pick_single_document(s)
+    if not doc:
+        return ''
+    doc = rewrite_triggers_to_dispatch(doc, path.name)
+    if not doc.endswith('\n'):
+        doc += '\n'
+    return doc
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--yes', action='store_true')
+    parser.add_argument('--out', '--out-dir', dest='out_dir')
+    args = parser.parse_args()
+
+    final_out_dir = Path(args.out_dir) if args.out_dir else OUT_DIR
+    if not ARCHIVE_DIR.exists():
+        print('Archive directory not found:', ARCHIVE_DIR)
+        sys.exit(1)
+    final_out_dir.mkdir(parents=True, exist_ok=True)
+    changed = []
+    for p in sorted(ARCHIVE_DIR.glob('*.yml')):
+        cleaned = clean_one(p)
+        out = final_out_dir / p.name
+        if not cleaned:
+            print(f'WARNING: {p.name} cleaned to empty content; skipping')
+            continue
+        orig = out.read_text(encoding='utf-8') if out.exists() else ''
+        if cleaned.strip() != orig.strip():
+            changed.append((p, out, cleaned))
+        else:
+            print(f'{p.name} unchanged')
+    if not changed:
+        print('No changes detected.')
+        return
+    if not args.yes:
+        ans = input(f'Write {len(changed)} cleaned files to {final_out_dir}? [y/N] ')
+        if ans.lower() != 'y':
+            print('Aborted.')
+            return
+    for p,out,cleaned in changed:
+        out.write_text(cleaned, encoding='utf-8')
+        print('WROTE', out)
+
+if __name__ == '__main__':
+    main()
+# Dry-run patched copy of tools/clean_workflows.py
+# Purpose: use CLEAN_WORKFLOWS_OUT_DIR -> TEST_TMPDIR -> repo path and ensure OUT_DIR exists
+import os
+from pathlib import Path
+try:
+    _env_out = os.environ.get('CLEAN_WORKFLOWS_OUT_DIR')
+    _test_tmp = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR')
+    OUT_DIR = Path(_env_out) if _env_out else (Path(_test_tmp) / 'workflows' if _test_tmp else Path('.github/workflows'))
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+except Exception:
+    OUT_DIR = Path('.github/workflows')
+
+# rest of logic omitted for dry-run

--- a/docs/dry_run_patches/applied/cleanup_empty_batch_directories_patched.py
+++ b/docs/dry_run_patches/applied/cleanup_empty_batch_directories_patched.py
@@ -1,0 +1,25 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/cleanup_empty_batch_directories.py
+
+Sets `PROCESSED_DIR` and `INTAKE_DIR` to test-scoped locations before importing
+to avoid removing directories from the repository during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+os.environ.setdefault('INTAKE_DIR', os.path.join(base, 'intake'))
+
+from doc_processor.dev_tools.cleanup_empty_batch_directories import main, cleanup_empty_dirs  # type: ignore
+
+__all__ = ['main', 'cleanup_empty_dirs']

--- a/docs/dry_run_patches/applied/cleanup_filing_cabinet_names_patched.py
+++ b/docs/dry_run_patches/applied/cleanup_filing_cabinet_names_patched.py
@@ -1,0 +1,110 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/cleanup_filing_cabinet_names.py`.
+
+Sets test-scoped filing cabinet path and re-exports main function.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('FILING_CABINET_DIR', str(Path(base) / 'filing_cabinet'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'cleanup_filing_cabinet_names.log'))
+
+try:
+    from doc_processor.dev_tools import cleanup_filing_cabinet_names as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'cleanup_filing_cabinet_names.py'
+    spec = importlib.util.spec_from_file_location('cleanup_filing_cabinet_names', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load cleanup_filing_cabinet_names module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+"""
+Dry-run wrapper for doc_processor/dev_tools/cleanup_filing_cabinet_names.py
+
+Sets `FILING_CABINET_CLEANUP_DIR` and `FILING_CABINET_DIR` to test-safe locations
+before importing so backups and logs are written under TEST_TMPDIR during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+
+# set default filing cabinet directory to a per-test folder if not already configured
+os.environ.setdefault('FILING_CABINET_DIR', os.path.join(base, 'filing_cabinet'))
+os.environ.setdefault('FILING_CABINET_CLEANUP_DIR', os.path.join(base, 'filing_cleanup'))
+
+from doc_processor.dev_tools.cleanup_filing_cabinet_names import FilingCabinetCleanup, main  # type: ignore
+
+__all__ = ['FilingCabinetCleanup', 'main']
+"""
+Dry-run patched wrapper for `doc_processor/dev_tools/cleanup_filing_cabinet_names.py`.
+
+Redirects backups/logs to TEST-safe locations and exposes the main class for dry-run testing.
+"""
+import os
+
+from doc_processor.dev_tools import cleanup_filing_cabinet_names as _orig
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir, ensure_dir
+except Exception:
+    from utils.path_utils import select_tmp_dir, ensure_dir  # type: ignore
+
+
+def _apply_test_safe_overrides():
+    # Prefer explicit override env var FILING_CABINET_CLEANUP_DIR, else use select_tmp_dir
+    cleanup_base = os.environ.get('FILING_CABINET_CLEANUP_DIR') or select_tmp_dir()
+    try:
+        ensure_dir(cleanup_base)
+    except Exception:
+        os.makedirs(cleanup_base, exist_ok=True)
+    os.environ['FILING_CABINET_CLEANUP_DIR'] = cleanup_base
+
+
+_apply_test_safe_overrides()
+
+# Expose the class for tests to instantiate
+FilingCabinetCleanup = _orig.FilingCabinetCleanup
+
+__all__ = ['FilingCabinetCleanup']
+# Dry-run patched copy of doc_processor/dev_tools/cleanup_filing_cabinet_names.py
+# Purpose: ensure backup_dir and log_file default to test-safe locations and honor env overrides
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('FILING_CABINET_CLEANUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# In __init__, replace cleanup_base resolution with:
+# cleanup_base = os.environ.get('FILING_CABINET_CLEANUP_DIR') or select_tmp_dir()
+# This ensures backups/logs default to a test-scoped area and avoid writing into the filing cabinet during tests.

--- a/docs/dry_run_patches/applied/cleanup_orphaned_wip_patched.py
+++ b/docs/dry_run_patches/applied/cleanup_orphaned_wip_patched.py
@@ -1,0 +1,24 @@
+"""
+Dry-run wrapper for dev_tools/cleanup_orphaned_wip.py
+
+Sets `PROCESSED_DIR` to a test-scoped directory (TEST_TMPDIR/select_tmp_dir)
+before importing to avoid clearing repo-local processed files during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+
+from dev_tools.cleanup_orphaned_wip import main, find_orphaned_wip  # type: ignore
+
+__all__ = ['main', 'find_orphaned_wip']

--- a/docs/dry_run_patches/applied/cleanup_test_artifacts_patched.py
+++ b/docs/dry_run_patches/applied/cleanup_test_artifacts_patched.py
@@ -1,0 +1,70 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/cleanup_test_artifacts.py`.
+
+Sets test-scoped directories before importing and re-exports main/cleanup functions.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('FILING_CABINET_DIR', str(Path(base) / 'filing_cabinet'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'cleanup_test_artifacts.log'))
+
+try:
+    # static analyzer may not resolve dev_tools submodules
+    from doc_processor.dev_tools import cleanup_test_artifacts as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'cleanup_test_artifacts.py'
+    spec = importlib.util.spec_from_file_location('cleanup_test_artifacts', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load cleanup_test_artifacts module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'cleanup', None)
+if _tmp is not None:
+    cleanup = _tmp
+    __all__.append('cleanup')
+"""
+Dry-run wrapper for dev_tools/cleanup_test_artifacts.py
+
+Ensures DB_BACKUP_DIR is set to a test-scoped path before importing the module so
+the tool does not operate on repository-local backup folders during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# Ensure TEST_TMPDIR exists and DB_BACKUP_DIR is overridden for tests
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+
+from dev_tools.cleanup_test_artifacts import main  # type: ignore
+
+__all__ = ['main']

--- a/docs/dry_run_patches/applied/clear_grouping_ordering_only_patched.py
+++ b/docs/dry_run_patches/applied/clear_grouping_ordering_only_patched.py
@@ -1,0 +1,45 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/clear_grouping_ordering_only.py`.
+
+Protects PROCESSED_DIR and database backup paths by routing to TEST_TMPDIR before importing.
+Re-exports main/clear functions when available.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'clear_grouping_ordering_only.log'))
+
+try:
+    from doc_processor.dev_tools import clear_grouping_ordering_only as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'clear_grouping_ordering_only.py'
+    spec = importlib.util.spec_from_file_location('clear_grouping_ordering_only', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load clear_grouping_ordering_only module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'clear_grouping_ordering_only', None)
+if _tmp is not None:
+    clear_grouping_ordering_only = _tmp
+    __all__.append('clear_grouping_ordering_only')

--- a/docs/dry_run_patches/applied/config_manager_patched.py
+++ b/docs/dry_run_patches/applied/config_manager_patched.py
@@ -1,0 +1,13 @@
+# Dry-run patched snippet for doc_processor/config_manager.py
+# Purpose: ensure DB_BACKUP_DIR and other output dirs prefer env/test tmp and are created safely
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('DB_BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example: when setting config.DB_BACKUP_DIR
+# db_backup = os.environ.get('DB_BACKUP_DIR') or select_tmp_dir()
+# os.makedirs(db_backup, exist_ok=True)

--- a/docs/dry_run_patches/applied/database_patched.py
+++ b/docs/dry_run_patches/applied/database_patched.py
@@ -1,0 +1,23 @@
+# Dry-run patched snippet for doc_processor/database.py
+# Purpose: ensure backup_root and override_dir use app_config/env or TEST_TMPDIR and are created
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('DB_BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example mapping
+
+def ensure_backup_root(backup_root):
+    mapped = os.environ.get('DB_BACKUP_DIR') or select_tmp_dir() or backup_root
+    try:
+        os.makedirs(mapped, exist_ok=True)
+    except Exception:
+        try:
+            os.makedirs(backup_root, exist_ok=True)
+            mapped = backup_root
+        except Exception:
+            pass
+    return mapped

--- a/docs/dry_run_patches/applied/database_setup_patched.py
+++ b/docs/dry_run_patches/applied/database_setup_patched.py
@@ -1,0 +1,35 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/database_setup.py
+
+Sets `DATABASE_PATH` and `DB_BACKUP_DIR` to test-scoped locations (prefer
+`TEST_TMPDIR`) before importing the original module to avoid touching real
+databases during tests/CI.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+def ensure_dir(p: str) -> None:
+    os.makedirs(p, exist_ok=True)
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+ensure_dir(base)
+
+# Respect an explicit DATABASE_PATH if provided; otherwise set a test DB
+if 'DATABASE_PATH' not in os.environ:
+    os.environ['DATABASE_PATH'] = os.path.join(base, 'documents_setup_test.db')
+
+# Default DB backup dir to test-scoped
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+
+from doc_processor.dev_tools.database_setup import main, create_schema  # type: ignore
+
+__all__ = ['main', 'create_schema']
+

--- a/docs/dry_run_patches/applied/db_backups_patched.py
+++ b/docs/dry_run_patches/applied/db_backups_patched.py
@@ -1,0 +1,45 @@
+"""
+Dry-run wrapper for DB backup utilities (doc_processor/dev_tools or db backup helpers).
+
+Sets DB_BACKUP_DIR and DATABASE_PATH to safe test-scoped paths before importing the real module.
+Re-exports common helpers like `create_backup` and `restore_backup` where available.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('DATABASE_PATH', str(Path(base) / 'documents.db'))
+
+try:
+    # The static analyzer may not resolve dev_tools submodules in some environments
+    from doc_processor.dev_tools import db_backups as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'db_backups.py'
+    spec = importlib.util.spec_from_file_location('db_backups', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load db_backups module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'create_backup', None)
+if _tmp is not None:
+    create_backup = _tmp
+    __all__.append('create_backup')
+_tmp = getattr(_original, 'restore_backup', None)
+if _tmp is not None:
+    restore_backup = _tmp
+    __all__.append('restore_backup')

--- a/docs/dry_run_patches/applied/db_connect_patched.py
+++ b/docs/dry_run_patches/applied/db_connect_patched.py
@@ -1,0 +1,44 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/db_connect.py`.
+
+Ensures `DATABASE_PATH` and `DB_BACKUP_DIR` point to test-scoped locations to avoid touching repo databases during tests.
+Re-exports connection helpers where present.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('DATABASE_PATH', str(Path(base) / 'documents_test.db'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+
+try:
+    from doc_processor.dev_tools import db_connect as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'db_connect.py'
+    spec = importlib.util.spec_from_file_location('db_connect', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load db_connect module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'database_connection', None)
+if _tmp is not None:
+    database_connection = _tmp
+    __all__.append('database_connection')
+_tmp = getattr(_original, 'connect', None)
+if _tmp is not None:
+    connect = _tmp
+    __all__.append('connect')

--- a/docs/dry_run_patches/applied/db_utils_patched.py
+++ b/docs/dry_run_patches/applied/db_utils_patched.py
@@ -1,0 +1,50 @@
+"""
+Dry-run wrapper for `doc_processor/db_utils.py`.
+
+Sets `DATABASE_PATH` and `DB_BACKUP_DIR` to a test-scoped location before importing the original module.
+Re-exports common helpers (if present) without causing import-time writes.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+# Test-scoped defaults
+os.environ.setdefault('DATABASE_PATH', str(Path(base) / 'documents_test.db'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+
+try:
+    from doc_processor import db_utils as _original
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'db_utils.py'
+    spec = importlib.util.spec_from_file_location('db_utils', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load db_utils module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+# Re-export helpers commonly used in tests (guarded via getattr)
+__all__ = []
+_tmp = getattr(_original, 'database_connection', None)
+if _tmp is not None:
+    database_connection = _tmp
+    __all__.append('database_connection')
+_tmp = getattr(_original, 'create_backup', None)
+if _tmp is not None:
+    create_backup = _tmp
+    __all__.append('create_backup')
+_tmp = getattr(_original, 'restore_backup', None)
+if _tmp is not None:
+    restore_backup = _tmp
+    __all__.append('restore_backup')

--- a/docs/dry_run_patches/applied/diagnose_grouping_block_patched.py
+++ b/docs/dry_run_patches/applied/diagnose_grouping_block_patched.py
@@ -1,0 +1,44 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/diagnose_grouping_block.py`.
+
+Sets test-scoped environment variables before importing and re-exports diagnostic functions.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'diagnose_grouping_block.log'))
+
+try:
+    from doc_processor.dev_tools import diagnose_grouping_block as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'diagnose_grouping_block.py'
+    spec = importlib.util.spec_from_file_location('diagnose_grouping_block', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load diagnose_grouping_block module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'diagnose', None)
+if _tmp is not None:
+    diagnose = _tmp
+    __all__.append('diagnose')

--- a/docs/dry_run_patches/applied/document_detector_patched.py
+++ b/docs/dry_run_patches/applied/document_detector_patched.py
@@ -1,0 +1,28 @@
+"""
+Dry-run wrapper for `doc_processor/document_detector.py`.
+
+Ensures normalization/cache directories are redirected to TEST_TMPDIR/select_tmp_dir
+before importing to avoid writing into the repository tree during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+
+# Default normalized/cache dirs
+os.environ.setdefault('NORMALIZED_DIR', os.path.join(base, 'normalized'))
+os.environ.setdefault('INTAKE_DIR', os.path.join(base, 'intake'))
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+
+from doc_processor import document_detector as original  # type: ignore
+
+__all__ = ['original']

--- a/docs/dry_run_patches/applied/document_processor_gca_patched.py
+++ b/docs/dry_run_patches/applied/document_processor_gca_patched.py
@@ -1,0 +1,383 @@
+"""Dry-run patched copy of Document_Scanner_Ollama_outdated/document_processor_gca.py
+
+This patched copy redirects repo-local output directories to test-safe locations using
+the project's helper selection logic when available. It's placed under docs/dry_run_patches/applied/
+for review and validation only. It does not change source files.
+"""
+import os
+import shutil
+import fitz
+import json
+import time
+import io
+import re
+from datetime import datetime, timedelta
+from PIL import Image
+import logging
+import warnings
+
+# Try to reuse project's helper to select test-safe tmp dirs; fall back to tempfile.gettempdir()
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*'pin_memory' argument is set as true but no accelerator is found.*"
+)
+
+try:
+    from prompts import CLASSIFICATION_PROMPT_TEMPLATE, TITLING_PROMPT_TEMPLATE, ORDERING_PROMPT
+except Exception:
+    CLASSIFICATION_PROMPT_TEMPLATE = ""
+    TITLING_PROMPT_TEMPLATE = ""
+    ORDERING_PROMPT = ""
+
+# Minimal config fallback using test-safe directories
+DRY_RUN = os.environ.get('DRY_RUN', 'true').lower() in ('1', 'true', 'yes')
+INTAKE_DIR = os.environ.get('INTAKE_DIR', os.path.join(select_tmp_dir(), 'intake'))
+PROCESSED_DIR = os.environ.get('PROCESSED_DIR', os.path.join(select_tmp_dir(), 'processed'))
+ARCHIVE_DIR = os.environ.get('ARCHIVE_DIR', os.path.join(select_tmp_dir(), 'archive'))
+LOG_FILE = os.environ.get('LOG_FILE', os.path.join(select_tmp_dir(), 'document_processor_gca.log'))
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
+MAX_RETRIES = int(os.environ.get('MAX_RETRIES', '3'))
+RETRY_DELAY_SECONDS = int(os.environ.get('RETRY_DELAY_SECONDS', '2'))
+ARCHIVE_RETENTION_DAYS = int(os.environ.get('ARCHIVE_RETENTION_DAYS', '30'))
+CATEGORIES = json.loads(os.environ.get('CATEGORIES_JSON', '{}') or '{}') or {'other': ''}
+
+log_level_map = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL
+}
+
+logging.basicConfig(
+    level=log_level_map.get(LOG_LEVEL.upper(), logging.INFO),
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE) if LOG_FILE else logging.NullHandler(),
+        logging.StreamHandler()
+    ]
+)
+
+model_cache_dir = os.path.join(select_tmp_dir(), 'model_cache')
+os.makedirs(model_cache_dir, exist_ok=True)
+
+try:
+    import ollama
+    import easyocr
+    import pytesseract
+    ocr_reader = easyocr.Reader(['en'], model_storage_directory=model_cache_dir)
+    ollama_client = ollama.Client(host=os.environ.get('OLLAMA_HOST', 'http://localhost:11434'))
+except Exception as e:
+    logging.warning(f"External LLM/OCR init failed in dry-run patched copy: {e}")
+    # continue as dry-run
+
+ABSOLUTE_CATEGORIES = {k: os.path.join(PROCESSED_DIR, v) for k, v in CATEGORIES.items()}
+for p in ABSOLUTE_CATEGORIES.values():
+    os.makedirs(p, exist_ok=True)
+os.makedirs(ARCHIVE_DIR, exist_ok=True)
+
+
+PAGE_MARKER_TEMPLATE = "\n\n--- Page {} ---\n\n"
+
+
+def cleanup_archive(directory: str, retention_days: int):
+    logging.info(f"Starting archive cleanup in '{directory}'. Deleting files older than {retention_days} days.")
+    now = datetime.now()
+    retention_limit = now - timedelta(days=retention_days)
+    try:
+        for filename in os.listdir(directory):
+            file_path = os.path.join(directory, filename)
+            if os.path.isfile(file_path):
+                try:
+                    mod_time = datetime.fromtimestamp(os.path.getmtime(file_path))
+                    if mod_time < retention_limit:
+                        if DRY_RUN:
+                            logging.info(f"[DRY RUN] Would have deleted old archive file: {file_path}")
+                        else:
+                            os.remove(file_path)
+                            logging.info(f"Deleted old archive file: {file_path}")
+                except Exception as e:
+                    logging.error(f"Error processing archive file '{file_path}' for cleanup: {e}")
+    except Exception as e:
+        logging.error(f"Failed to list files in archive directory '{directory}': {e}")
+
+
+def merge_pdfs(pdf_list: list[str], output_path: str) -> str | None:
+    result_pdf = fitz.open()
+    try:
+        for pdf_path in pdf_list:
+            try:
+                with fitz.open(pdf_path) as pdf_doc:
+                    result_pdf.insert_pdf(pdf_doc)
+            except Exception as e:
+                logging.error(f"Could not process '{pdf_path}' during merge and will be skipped. Error: {e}")
+        os.makedirs(os.path.dirname(output_path) or select_tmp_dir(), exist_ok=True)
+        result_pdf.save(output_path)
+        return output_path
+    except Exception as e:
+        logging.error(f"A critical error occurred during the PDF merge operation: {e}")
+        return None
+    finally:
+        result_pdf.close()
+
+
+def perform_ocr_on_pdf(file_path: str) -> tuple[str, int]:
+    page_count = 0
+    full_extracted_text = ""
+    doc: fitz.Document | None = None
+    try:
+        doc = fitz.open(file_path)
+        page_count = doc.page_count
+        for i, page in enumerate(doc):
+            page_number = i + 1
+            full_extracted_text += PAGE_MARKER_TEMPLATE.format(page_number)
+            current_page_text = page.get_text().strip()
+            if not current_page_text:
+                pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
+                img = Image.open(io.BytesIO(pix.tobytes("png")))
+                try:
+                    osd = pytesseract.image_to_osd(img, output_type=pytesseract.Output.DICT)
+                    rotation = osd.get('rotate', 0)
+                    if rotation > 0:
+                        img = img.rotate(-rotation, expand=True)
+                except Exception:
+                    pass
+                img_byte_arr = io.BytesIO()
+                img.save(img_byte_arr, format='PNG')
+                img_bytes = img_byte_arr.getvalue()
+                try:
+                    results = ocr_reader.readtext(img_bytes, detail=0, paragraph=True)
+                    current_page_text = "\n".join(map(str, results))
+                except Exception:
+                    current_page_text = ""
+            full_extracted_text += current_page_text
+        return full_extracted_text, page_count
+    except Exception as e:
+        logging.error(f"A critical error occurred during OCR on '{file_path}': {e}")
+        return "", page_count
+    finally:
+        if doc:
+            doc.close()
+
+
+def create_output_files(source_pdf_path: str, category: str, title: str):
+    file_name = os.path.basename(source_pdf_path)
+    text_for_report = ""
+    ocr_doc_obj = None
+    doc: fitz.Document | None = None
+    reason = "Success"
+    try:
+        doc = fitz.open(source_pdf_path)
+        ocr_doc_obj = fitz.open()
+        for page in doc:
+            page_text = page.get_text().strip()
+            if not page_text:
+                pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
+                img = Image.open(io.BytesIO(pix.tobytes("png")))
+                try:
+                    osd = pytesseract.image_to_osd(img, output_type=pytesseract.Output.DICT)
+                    rotation = osd.get('rotate', 0)
+                    if rotation > 0:
+                        img = img.rotate(-rotation, expand=True)
+                except Exception:
+                    pass
+                img_byte_arr = io.BytesIO()
+                img.save(img_byte_arr, format='PNG')
+                img_bytes = img_byte_arr.getvalue()
+                try:
+                    results = ocr_reader.readtext(img_bytes, detail=0, paragraph=True)
+                    page_text = "\n".join(map(str, results))
+                except Exception:
+                    page_text = ""
+            text_for_report += page_text + "\n\n"
+            new_page = ocr_doc_obj.new_page(width=page.rect.width, height=page.rect.height)
+            pix = page.get_pixmap()
+            new_page.insert_image(new_page.rect, stream=io.BytesIO(pix.tobytes("png")))
+            new_page.insert_text(page.rect.tl, page_text, render_mode=3)
+    except Exception as e:
+        logging.error(f"Error during final OCR pass for '{file_name}': {e}")
+        reason = f"Final OCR pass failed due to: {e}"
+    finally:
+        if doc:
+            doc.close()
+
+    sanitized_title = "".join(c for c in title if c.isalnum() or c in (' ', '.', '-', '_', '(', ')')).rstrip().replace(' ', '_')
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    new_name_base = f"{category}_{sanitized_title}_{timestamp}"
+    destination_dir = ABSOLUTE_CATEGORIES.get(category, ABSOLUTE_CATEGORIES.get("other", os.path.join(PROCESSED_DIR, 'other')))
+    os.makedirs(destination_dir, exist_ok=True)
+    original_copy_path = os.path.join(destination_dir, f"{new_name_base}.pdf")
+    ocr_copy_path = os.path.join(destination_dir, f"{new_name_base}_ocr.pdf")
+    markdown_path = os.path.join(destination_dir, f"{new_name_base}.md")
+    try:
+        if DRY_RUN:
+            logging.info(f"[DRY RUN] Would create the following files in '{destination_dir}': {original_copy_path}, {ocr_copy_path}, {markdown_path}")
+        else:
+            shutil.copy2(source_pdf_path, original_copy_path)
+            if ocr_doc_obj:
+                ocr_doc_obj.save(ocr_copy_path, garbage=4, deflate=True)
+            markdown_content = f"""# Document Analysis Report\n\n## Source File: {file_name}\n## Assigned Category: {category}\n## Assigned Title: {title}\n\n---\n\n## Extracted Text (OCR)\n\n```
+{text_for_report.strip()}
+```
+\n---\n\n## Processing Summary\n- **Status:** {reason}\n"""
+            with open(markdown_path, "w", encoding="utf-8") as md_file:
+                md_file.write(markdown_content)
+    except Exception as e:
+        logging.error(f"Error saving final output files for '{file_name}': {e}")
+    finally:
+        if ocr_doc_obj:
+            ocr_doc_obj.close()
+
+
+def split_and_process_pdf(original_pdf_path: str, final_documents: list[dict]):
+    temp_files_to_clean = []
+    original_doc: fitz.Document | None = None
+    try:
+        original_doc = fitz.open(original_pdf_path)
+        for i, doc_details in enumerate(final_documents):
+            pages_to_include = doc_details.get('page_order', [])
+            category = doc_details.get('category')
+            title = doc_details.get('title')
+            if not all([pages_to_include, category, title]):
+                continue
+            new_doc = fitz.open()
+            zero_indexed_pages = [p - 1 for p in pages_to_include]
+            for page_num in zero_indexed_pages:
+                if 0 <= page_num < original_doc.page_count:
+                    new_doc.insert_pdf(original_doc, from_page=page_num, to_page=page_num)
+            temp_pdf_path = os.path.join(os.path.dirname(original_pdf_path) or select_tmp_dir(), f"temp_split_{i}_{os.path.basename(original_pdf_path)}")
+            os.makedirs(os.path.dirname(temp_pdf_path) or select_tmp_dir(), exist_ok=True)
+            new_doc.save(temp_pdf_path)
+            new_doc.close()
+            temp_files_to_clean.append(temp_pdf_path)
+            create_output_files(temp_pdf_path, category, title)
+        return temp_files_to_clean
+    except Exception as e:
+        logging.error(f"A critical error occurred during the PDF splitting and processing stage for '{original_pdf_path}': {e}")
+        return temp_files_to_clean
+    finally:
+        if original_doc:
+            original_doc.close()
+
+
+def main():
+    logging.info("Starting dry-run patched document processor (GCA variant)")
+    cleanup_archive(ARCHIVE_DIR, ARCHIVE_RETENTION_DAYS)
+    try:
+        initial_files = [os.path.join(INTAKE_DIR, f) for f in os.listdir(INTAKE_DIR) if f.lower().endswith('.pdf') and os.path.isfile(os.path.join(INTAKE_DIR, f))]
+    except FileNotFoundError:
+        logging.critical(f"The intake directory '{INTAKE_DIR}' does not exist. Halting.")
+        return
+    if not initial_files:
+        logging.info("No new PDF files found in the intake directory. Scan complete.")
+        return
+    file_to_process = None
+    temp_merged_path = None
+    if len(initial_files) > 1:
+        temp_merged_name = f"temp_mega_batch_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf"
+        temp_merged_path = os.path.join(INTAKE_DIR, temp_merged_name)
+        file_to_process = merge_pdfs(initial_files, temp_merged_path)
+    elif len(initial_files) == 1:
+        file_to_process = initial_files[0]
+    if not file_to_process:
+        logging.error("Failed to prepare a file for processing (merge might have failed). Halting run.")
+        return
+    file_name = os.path.basename(file_to_process)
+    try:
+        with fitz.open(file_to_process) as doc:
+            all_input_pages = set(range(1, doc.page_count + 1))
+    except Exception as e:
+        logging.critical(f"Could not open and count pages in '{file_name}'. Halting. Error: {e}")
+        return
+    processed_successfully = False
+    temp_split_paths: list[str] = []
+    try:
+        full_pdf_text, page_count = perform_ocr_on_pdf(file_to_process)
+        if not full_pdf_text:
+            raise ValueError("Initial OCR failed to extract any text. Cannot proceed.")
+        page_classifications = []
+        for i in range(1, page_count + 1):
+            page_text = re.search(r'--- Page ' + str(i) + r' ---\n(.*?)(?=\n--- Page|\Z)', full_pdf_text, re.S)
+            page_text = page_text.group(1) if page_text else ''
+            if not page_text.strip():
+                page_classifications.append({'page_num': i, 'category': 'other'})
+                continue
+            category = 'other'
+            page_classifications.append({'page_num': i, 'category': category})
+        document_groups: list[dict] = []
+        if page_classifications:
+            current_group_pages = [page_classifications[0]['page_num']]
+            current_category = page_classifications[0]['category']
+            for i in range(1, len(page_classifications)):
+                page_num, category = page_classifications[i]['page_num'], page_classifications[i]['category']
+                if category == current_category:
+                    current_group_pages.append(page_num)
+                else:
+                    document_groups.append({'category': current_category, 'pages': current_group_pages})
+                    current_group_pages = [page_num]
+                    current_category = category
+            document_groups.append({'category': current_category, 'pages': current_group_pages})
+        final_documents = []
+        for group in document_groups:
+            pages = group['pages']
+            category = group['category']
+            group_text_blob = ''.join(PAGE_MARKER_TEMPLATE.format(page_num) + (re.search(r'--- Page ' + str(page_num) + r' ---\n(.*?)(?=\n--- Page|\Z)', full_pdf_text, re.S) or '').group(1) if re.search(r'') else '' for page_num in pages)
+            title = f"doc_{pages[0]}_{pages[-1]}"
+            page_order = pages
+            final_documents.append({'category': category, 'title': title, 'page_order': page_order})
+        temp_split_paths = split_and_process_pdf(file_to_process, final_documents)
+        processed_successfully = True
+    except Exception as e:
+        logging.critical(f"A critical, unhandled error occurred while processing '{file_name}': {e}", exc_info=True)
+        processed_successfully = False
+    finally:
+        if processed_successfully:
+            for original_file in initial_files:
+                if os.path.exists(original_file):
+                    if DRY_RUN:
+                        logging.info(f"[DRY RUN] Would archive original file: {os.path.basename(original_file)}")
+                    else:
+                        try:
+                            shutil.move(original_file, os.path.join(ARCHIVE_DIR, os.path.basename(original_file)))
+                        except Exception as e:
+                            logging.error(f"Failed to archive original file '{os.path.basename(original_file)}': {e}")
+        if temp_merged_path and os.path.exists(temp_merged_path):
+            try:
+                os.remove(temp_merged_path)
+            except Exception:
+                pass
+        if temp_split_paths:
+            for temp_path in temp_split_paths:
+                if os.path.exists(temp_path):
+                    try:
+                        os.remove(temp_path)
+                    except Exception:
+                        pass
+
+
+if __name__ == '__main__':
+    main()
+# Dry-run patched copy of Document_Scanner_Ollama_outdated/document_processor_gca.py
+# Similar mapping for cache/archive dirs
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example mapping usage
+CACHE_DIR = os.environ.get('GCA_CACHE_DIR') or select_tmp_dir()
+try:
+    os.makedirs(CACHE_DIR, exist_ok=True)
+except Exception:
+    CACHE_DIR = os.path.join(os.getcwd(), 'gca_cache')
+    os.makedirs(CACHE_DIR, exist_ok=True)

--- a/docs/dry_run_patches/applied/document_processor_gem_patched.py
+++ b/docs/dry_run_patches/applied/document_processor_gem_patched.py
@@ -1,0 +1,371 @@
+"""Dry-run patched copy of Document_Scanner_Ollama_outdated/document_processor_gem.py
+Redirects repo-local outputs to TEST_TMPDIR-safe locations when possible.
+"""
+import os
+import shutil
+import fitz
+import json
+import time
+import io
+import re
+from datetime import datetime, timedelta
+from PIL import Image
+import logging
+import warnings
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*'pin_memory' argument is set as true but no accelerator is found.*"
+)
+
+# Minimal fallbacks
+DRY_RUN = os.environ.get('DRY_RUN', 'true').lower() in ('1', 'true', 'yes')
+INTAKE_DIR = os.environ.get('INTAKE_DIR', os.path.join(select_tmp_dir(), 'intake'))
+PROCESSED_DIR = os.environ.get('PROCESSED_DIR', os.path.join(select_tmp_dir(), 'processed'))
+ARCHIVE_DIR = os.environ.get('ARCHIVE_DIR', os.path.join(select_tmp_dir(), 'archive'))
+LOG_FILE = os.environ.get('LOG_FILE', os.path.join(select_tmp_dir(), 'document_processor_gem.log'))
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
+MAX_RETRIES = int(os.environ.get('MAX_RETRIES', '3'))
+RETRY_DELAY_SECONDS = int(os.environ.get('RETRY_DELAY_SECONDS', '2'))
+ARCHIVE_RETENTION_DAYS = int(os.environ.get('ARCHIVE_RETENTION_DAYS', '30'))
+try:
+    CATEGORIES = json.loads(os.environ.get('CATEGORIES_JSON', '{}') or '{}') or {'other': ''}
+except Exception:
+    CATEGORIES = {'other': ''}
+
+log_level_map = {"DEBUG": logging.DEBUG, "INFO": logging.INFO, "WARNING": logging.WARNING, "ERROR": logging.ERROR, "CRITICAL": logging.CRITICAL}
+logging.basicConfig(level=log_level_map.get(LOG_LEVEL.upper(), logging.INFO), format='%(asctime)s - %(levelname)s - %(message)s', handlers=[logging.FileHandler(LOG_FILE) if LOG_FILE else logging.NullHandler(), logging.StreamHandler()])
+
+model_cache_dir = os.path.join(select_tmp_dir(), 'model_cache')
+os.makedirs(model_cache_dir, exist_ok=True)
+try:
+    import ollama
+    import easyocr
+    import pytesseract
+    ocr_reader = easyocr.Reader(['en'], model_storage_directory=model_cache_dir)
+    ollama_client = ollama.Client(host=os.environ.get('OLLAMA_HOST', 'http://localhost:11434'))
+except Exception as e:
+    logging.warning(f"External LLM/OCR init failed in dry-run patched copy: {e}")
+
+ABSOLUTE_CATEGORIES = {category_name: os.path.join(PROCESSED_DIR, relative_path) for category_name, relative_path in CATEGORIES.items()}
+for category_path in ABSOLUTE_CATEGORIES.values():
+    os.makedirs(category_path, exist_ok=True)
+os.makedirs(ARCHIVE_DIR, exist_ok=True)
+
+PAGE_MARKER_TEMPLATE = "\n\n--- Page {} ---\n\n"
+
+def cleanup_archive(directory: str, retention_days: int):
+    now = datetime.now()
+    retention_limit = now - timedelta(days=retention_days)
+    try:
+        for filename in os.listdir(directory):
+            file_path = os.path.join(directory, filename)
+            if os.path.isfile(file_path):
+                try:
+                    mod_time = datetime.fromtimestamp(os.path.getmtime(file_path))
+                    if mod_time < retention_limit:
+                        if DRY_RUN:
+                            logging.info(f"[DRY RUN] Would have deleted old archive file: {file_path}")
+                        else:
+                            os.remove(file_path)
+                except Exception as e:
+                    logging.error(f"Error processing archive file '{file_path}' for cleanup: {e}")
+    except Exception as e:
+        logging.error(f"Failed to list files in archive directory '{directory}': {e}")
+
+def merge_pdfs(pdf_list: list[str], output_path: str) -> str | None:
+    result_pdf = fitz.open()
+    try:
+        for pdf_path in pdf_list:
+            try:
+                with fitz.open(pdf_path) as pdf_doc:
+                    result_pdf.insert_pdf(pdf_doc)
+            except Exception as e:
+                logging.error(f"Could not process '{pdf_path}' during merge: {e}")
+        os.makedirs(os.path.dirname(output_path) or select_tmp_dir(), exist_ok=True)
+        result_pdf.save(output_path)
+        return output_path
+    except Exception as e:
+        logging.error(f"Merge failed: {e}")
+        return None
+    finally:
+        result_pdf.close()
+
+def perform_ocr_on_pdf(file_path: str) -> tuple[str, int]:
+    page_count = 0
+    full_extracted_text = ""
+    doc: fitz.Document | None = None
+    try:
+        doc = fitz.open(file_path)
+        page_count = doc.page_count
+        for i, page in enumerate(doc):
+            page_number = i + 1
+            full_extracted_text += PAGE_MARKER_TEMPLATE.format(page_number)
+            current_page_text = page.get_text().strip()
+            if not current_page_text:
+                pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
+                img = Image.open(io.BytesIO(pix.tobytes("png")))
+                try:
+                    osd = pytesseract.image_to_osd(img, output_type=pytesseract.Output.DICT)
+                    rotation = osd.get('rotate', 0)
+                    if rotation > 0:
+                        img = img.rotate(-rotation, expand=True)
+                except Exception:
+                    pass
+                img_byte_arr = io.BytesIO()
+                img.save(img_byte_arr, format='PNG')
+                img_bytes = img_byte_arr.getvalue()
+                try:
+                    results = ocr_reader.readtext(img_bytes, detail=0, paragraph=True)
+                    current_page_text = "\n".join(map(str, results))
+                except Exception:
+                    current_page_text = ""
+            full_extracted_text += current_page_text
+        return full_extracted_text, page_count
+    except Exception as e:
+        logging.error(f"OCR failed for '{file_path}': {e}")
+        return "", page_count
+    finally:
+        if doc:
+            doc.close()
+
+def create_output_files(source_pdf_path: str, sub_category: str, title: str, parent_category_path: str):
+    file_name = os.path.basename(source_pdf_path)
+    text_for_report = ""
+    ocr_doc_obj = None
+    doc: fitz.Document | None = None
+    reason = "Success"
+    try:
+        doc = fitz.open(source_pdf_path)
+        ocr_doc_obj = fitz.open()
+        for page in doc:
+            page_text = page.get_text().strip()
+            if not page_text:
+                pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
+                img = Image.open(io.BytesIO(pix.tobytes("png")))
+                try:
+                    osd = pytesseract.image_to_osd(img, output_type=pytesseract.Output.DICT)
+                    rotation = osd.get('rotate', 0)
+                    if rotation > 0:
+                        img = img.rotate(-rotation, expand=True)
+                except Exception:
+                    pass
+                img_byte_arr = io.BytesIO()
+                img.save(img_byte_arr, format='PNG')
+                img_bytes = img_byte_arr.getvalue()
+                try:
+                    results = ocr_reader.readtext(img_bytes, detail=0, paragraph=True)
+                    page_text = "\n".join(map(str, results))
+                except Exception:
+                    page_text = ""
+            text_for_report += page_text + "\n\n"
+            new_page = ocr_doc_obj.new_page(width=page.rect.width, height=page.rect.height)
+            pix = page.get_pixmap()
+            new_page.insert_image(new_page.rect, stream=io.BytesIO(pix.tobytes("png")))
+            new_page.insert_text(page.rect.tl, page_text, render_mode=3)
+    except Exception as e:
+        logging.error(f"Final OCR pass failed for '{file_name}': {e}")
+        reason = f"Final OCR pass failed due to: {e}"
+    finally:
+        if doc:
+            doc.close()
+    sanitized_sub_category = "".join(c for c in sub_category if c.isalnum() or c in (' ', '-', '_')).rstrip().replace(' ', '_')
+    sanitized_title = "".join(c for c in title if c.isalnum() or c in (' ', '.', '-', '_', '(', ')')).rstrip().replace(' ', '_')
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    new_name_base = f"{sanitized_sub_category}_{sanitized_title}_{timestamp}"
+    destination_dir = parent_category_path
+    os.makedirs(destination_dir, exist_ok=True)
+    original_copy_path = os.path.join(destination_dir, f"{new_name_base}.pdf")
+    ocr_copy_path = os.path.join(destination_dir, f"{new_name_base}_ocr.pdf")
+    markdown_path = os.path.join(destination_dir, f"{new_name_base}.md")
+    try:
+        if DRY_RUN:
+            logging.info(f"[DRY RUN] Would create files for {file_name} in '{destination_dir}'")
+        else:
+            shutil.copy2(source_pdf_path, original_copy_path)
+            if ocr_doc_obj:
+                ocr_doc_obj.save(ocr_copy_path, garbage=4, deflate=True)
+            markdown_content = f"""# Document Analysis Report\n\n## Source File: {file_name}\n## Assigned Category: {sub_category}\n## Assigned Title: {title}\n\n---\n\n## Extracted Text (OCR)\n\n```
+{text_for_report.strip()}
+```
+\n---\n\n## Processing Summary\n- **Status:** {reason}"""
+            with open(markdown_path, "w", encoding="utf-8") as md_file:
+                md_file.write(markdown_content)
+    except Exception as e:
+        logging.error(f"Error saving final files for '{file_name}': {e}")
+    finally:
+        if ocr_doc_obj:
+            ocr_doc_obj.close()
+
+def split_and_process_pdf(original_pdf_path: str, final_documents: list[dict]) -> list[str]:
+    temp_files_to_clean = []
+    original_doc: fitz.Document | None = None
+    try:
+        original_doc = fitz.open(original_pdf_path)
+        for i, doc_details in enumerate(final_documents):
+            pages_to_include = doc_details.get('page_order', [])
+            category = doc_details.get('category')
+            sub_category = doc_details.get('sub_category')
+            title = doc_details.get('title')
+            if not pages_to_include or not category or not sub_category or not title:
+                logging.warning(f"Skipping incomplete document group #{i+1} due to missing data: {doc_details}")
+                continue
+            new_doc = fitz.open()
+            zero_indexed_pages = [p - 1 for p in pages_to_include]
+            for page_num in zero_indexed_pages:
+                if 0 <= page_num < original_doc.page_count:
+                    new_doc.insert_pdf(original_doc, from_page=page_num, to_page=page_num)
+            temp_pdf_path = os.path.join(os.path.dirname(original_pdf_path) or select_tmp_dir(), f"temp_split_{i}_{os.path.basename(original_pdf_path)}")
+            os.makedirs(os.path.dirname(temp_pdf_path) or select_tmp_dir(), exist_ok=True)
+            new_doc.save(temp_pdf_path)
+            new_doc.close()
+            temp_files_to_clean.append(temp_pdf_path)
+            parent_category_path = ABSOLUTE_CATEGORIES.get(category, ABSOLUTE_CATEGORIES.get("other", os.path.join(PROCESSED_DIR, 'other')))
+            create_output_files(temp_pdf_path, sub_category, title, parent_category_path)
+        return temp_files_to_clean
+    except Exception as e:
+        logging.error(f"Error during splitting and processing for {original_pdf_path}: {e}")
+        return temp_files_to_clean
+    finally:
+        if original_doc:
+            original_doc.close()
+
+def main():
+    cleanup_archive(ARCHIVE_DIR, ARCHIVE_RETENTION_DAYS)
+    try:
+        initial_files = [os.path.join(INTAKE_DIR, f) for f in os.listdir(INTAKE_DIR) if f.lower().endswith('.pdf') and os.path.isfile(os.path.join(INTAKE_DIR, f))]
+    except FileNotFoundError:
+        logging.critical(f"The intake directory '{INTAKE_DIR}' does not exist. Halting.")
+        return
+    if not initial_files:
+        logging.info("No new PDF files found.")
+        return
+    file_to_process = None
+    temp_merged_path = None
+    if len(initial_files) > 1:
+        temp_merged_name = f"temp_mega_batch_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf"
+        temp_merged_path = os.path.join(INTAKE_DIR, temp_merged_name)
+        file_to_process = merge_pdfs(initial_files, temp_merged_path)
+    elif len(initial_files) == 1:
+        file_to_process = initial_files[0]
+    if not file_to_process:
+        logging.error("Failed to prepare a file for processing.")
+        return
+    file_name = os.path.basename(file_to_process)
+    all_input_pages = set()
+    try:
+        with fitz.open(file_to_process) as doc:
+            all_input_pages = set(range(1, doc.page_count + 1))
+    except Exception as e:
+        logging.critical(f"Could not open and count pages in '{file_name}'. Halting. Error: {e}")
+        return
+    processed_successfully = False
+    temp_split_paths: list[str] = []
+    try:
+        full_pdf_text, page_count = perform_ocr_on_pdf(file_to_process)
+        if not full_pdf_text:
+            raise ValueError("Initial OCR failed to extract any text.")
+        recent_categories: list[str] = []
+        page_classifications = []
+        for i in range(1, page_count + 1):
+            page_text = get_text_for_page(full_pdf_text, i)
+            if not page_text.strip():
+                page_classifications.append({'page_num': i, 'category': 'other'})
+                continue
+            category = 'other'
+            page_classifications.append({'page_num': i, 'category': category})
+        document_groups: list[dict] = []
+        if page_classifications:
+            current_group_pages = [page_classifications[0]['page_num']]
+            current_category = page_classifications[0]['category']
+            for i in range(1, len(page_classifications)):
+                page_num, category = page_classifications[i]['page_num'], page_classifications[i]['category']
+                if category == current_category:
+                    current_group_pages.append(page_num)
+                else:
+                    document_groups.append({'category': current_category, 'pages': current_group_pages})
+                    current_group_pages = [page_num]
+                    current_category = category
+            document_groups.append({'category': current_category, 'pages': current_group_pages})
+        final_documents = []
+        for group in document_groups:
+            pages = group['pages']
+            category = group['category']
+            group_text_blob = ''.join(PAGE_MARKER_TEMPLATE.format(page_num) + get_text_for_page(full_pdf_text, page_num) for page_num in pages)
+            sub_category = 'default'
+            title = f"doc_{pages[0]}_{pages[-1]}"
+            page_order = pages
+            final_documents.append({'category': category, 'sub_category': sub_category, 'title': title, 'page_order': page_order})
+        temp_split_paths = split_and_process_pdf(file_to_process, final_documents)
+        processed_successfully = True
+    except Exception as e:
+        logging.critical(f"A critical, unhandled error occurred during processing of '{file_name}': {e}", exc_info=True)
+    finally:
+        if processed_successfully:
+            for original_file in initial_files:
+                if os.path.exists(original_file):
+                    if DRY_RUN:
+                        logging.info(f"[DRY RUN] Would archive original file: {os.path.basename(original_file)}")
+                    else:
+                        try:
+                            shutil.move(original_file, os.path.join(ARCHIVE_DIR, os.path.basename(original_file)))
+                        except Exception as e:
+                            logging.error(f"Failed to archive original file '{os.path.basename(original_file)}': {e}")
+        if temp_merged_path and os.path.exists(temp_merged_path):
+            try:
+                os.remove(temp_merged_path)
+            except Exception:
+                pass
+        if temp_split_paths:
+            for temp_path in temp_split_paths:
+                if os.path.exists(temp_path):
+                    try:
+                        os.remove(temp_path)
+                    except Exception:
+                        pass
+
+if __name__ == '__main__':
+    main()
+# Dry-run patched copy of Document_Scanner_Ollama_outdated/document_processor_gem.py
+# Purpose: map destination_dir to a test-safe base when possible.
+
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example of replacing the write block inside create_output_files
+
+def create_output_files_safe_example(destination_dir, source_pdf_path, md_content):
+    # Preserve explicit env override
+    env_dest = os.environ.get('ARCHIVE_DIR')
+    safe_base = env_dest or select_tmp_dir()
+    mapped_dest = os.path.join(safe_base, os.path.basename(destination_dir)) if safe_base else destination_dir
+    try:
+        os.makedirs(mapped_dest, exist_ok=True)
+    except Exception:
+        mapped_dest = destination_dir
+        os.makedirs(mapped_dest, exist_ok=True)
+
+    original_copy_path = os.path.join(mapped_dest, os.path.basename(source_pdf_path))
+    try:
+        shutil.copy2(source_pdf_path, original_copy_path)
+    except Exception as e:
+        # fallback to original destination if needed
+        fallback_path = os.path.join(destination_dir, os.path.basename(source_pdf_path))
+        shutil.copy2(source_pdf_path, fallback_path)
+
+    # Write markdown to mapped_dest
+    md_path = os.path.join(mapped_dest, 'report.md')
+    with open(md_path, 'w', encoding='utf-8') as md_file:
+        md_file.write(md_content)

--- a/docs/dry_run_patches/applied/document_processor_gemini_patched.py
+++ b/docs/dry_run_patches/applied/document_processor_gemini_patched.py
@@ -1,0 +1,57 @@
+"""
+Dry-run wrapper for archive/Document_Scanner_Gemini_outdated/document_processor.py
+Redirects legacy outputs to TEST_TMPDIR/select_tmp_dir during tests. Falls back to file-load if package import not available.
+"""
+
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return tempfile.gettempdir()
+
+base = os.environ.get("TEST_TMPDIR") or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+for k in (
+    "ARCHIVE_DIR",
+    "OUTPUT_DIR",
+    "CACHE_DIR",
+    "PROCESSED_DIR",
+    "EXPORT_DIR",
+    "FILING_CABINET_DIR",
+    "LOG_FILE_PATH",
+    "DOWNLOAD_DIR",
+):
+    os.environ.setdefault(k, str(Path(base) / k.lower()))
+
+# Try a normal import first, then fall back to a file-based import which is resilient to non-package layout
+try:
+    from Document_Scanner_Gemini_outdated import document_processor as _original
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    # Try both archive/Document_Scanner_Gemini_outdated and archive/legacy/Document_Scanner_Gemini_outdated
+    paths_to_try = [
+        repo_root / "archive" / "Document_Scanner_Gemini_outdated" / "document_processor.py",
+        repo_root / "archive" / "legacy" / "Document_Scanner_Gemini_outdated" / "document_processor.py",
+    ]
+    for candidate in paths_to_try:
+        if candidate.exists():
+            spec = importlib.util.spec_from_file_location("legacy_document_processor", str(candidate))
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)  # type: ignore
+            _original = mod
+            break
+    else:
+        raise
+
+if hasattr(_original, "main"):
+    main = _original.main
+if hasattr(_original, "process_documents"):
+    process_documents = _original.process_documents
+
+__all__ = [name for name in ("main", "process_documents") if name in globals()]

--- a/docs/dry_run_patches/applied/download_manager_gui_patched.py
+++ b/docs/dry_run_patches/applied/download_manager_gui_patched.py
@@ -1,0 +1,34 @@
+"""
+Dry-run wrapper for tools/download_manager/download_manager_gui.py
+
+Ensures GUI download functions default to TEST_TMPDIR/select_tmp_dir when no
+download_dir is provided to avoid writing into repo during test runs.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Optional
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+os.environ.setdefault('DOWNLOAD_DIR', os.path.join(os.environ.get('TEST_TMPDIR') or select_tmp_dir(), 'downloads'))
+
+from tools.download_manager.download_manager_gui import download_files_from_url as _download_gui  # type: ignore
+from typing import Any
+
+
+def download_files_from_url(url: str, download_dir: Optional[str] = None, *args: Any, **kwargs: Any):
+    # Guarantee a non-None str value for the wrapped call so static checkers are happy
+    download_dir = (
+        download_dir
+        or os.environ.get('DOWNLOAD_DIR')
+        or select_tmp_dir()
+    )
+    return _download_gui(url, download_dir, *args, **kwargs)
+
+__all__ = ['download_files_from_url']

--- a/docs/dry_run_patches/applied/download_manager_patched.py
+++ b/docs/dry_run_patches/applied/download_manager_patched.py
@@ -1,0 +1,34 @@
+"""
+Dry-run wrapper for tools/download_manager/download_manager.py
+
+Provides a safe helper `download_files_from_url_safe` that defaults to a test-scoped
+directory (select_tmp_dir()) when `download_dir` is omitted. Re-exports the original
+`download_files_from_url` for callers that want the raw function.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Optional
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+from tools.download_manager.download_manager import download_files_from_url  # type: ignore
+
+def download_files_from_url_safe(url: str, download_dir: Optional[str] = None, **kwargs):
+    """Call the original downloader but default the destination to a test-safe dir.
+
+    Args:
+        url: remote directory URL
+        download_dir: optional local path. If None, use select_tmp_dir().
+        kwargs: passed to original function (max_retries, retry_delay)
+    """
+    if not download_dir:
+        download_dir = select_tmp_dir()
+    return download_files_from_url(url, download_dir, **kwargs)
+
+__all__ = ['download_files_from_url', 'download_files_from_url_safe']

--- a/docs/dry_run_patches/applied/export_patched.py
+++ b/docs/dry_run_patches/applied/export_patched.py
@@ -1,0 +1,51 @@
+"""
+Dry-run patched wrapper for `doc_processor/routes/export.py`.
+
+This wrapper ensures that `app_config.FILING_CABINET_DIR` and other
+filesystem-facing config values are set to test-safe locations (preferring
+explicit env overrides, then TEST_TMPDIR, then system tempdir) before the
+original module uses them. It re-exports the `bp` Blueprint for lightweight
+integration tests.
+"""
+import os
+import logging
+
+from doc_processor.routes import export as _orig
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir, ensure_dir
+except Exception:
+    from utils.path_utils import select_tmp_dir, ensure_dir  # type: ignore
+
+
+def _apply_test_safe_filing_dir():
+    try:
+        from doc_processor.config_manager import app_config as ac
+    except Exception:
+        ac = getattr(_orig, 'app_config', None)
+
+    # Prefer explicit env var, then existing app_config value, then select_tmp_dir()
+    filing = os.getenv('FILING_CABINET_DIR') or (getattr(ac, 'FILING_CABINET_DIR', None) if ac else None) or select_tmp_dir()
+    try:
+        ensure_dir(filing)
+    except Exception:
+        try:
+            os.makedirs(filing, exist_ok=True)
+        except Exception:
+            logging.debug(f"export_patched: could not ensure filing dir {filing}")
+
+    if ac:
+        try:
+            setattr(ac, 'FILING_CABINET_DIR', filing)
+        except Exception:
+            pass
+    os.environ['FILING_CABINET_DIR'] = filing
+
+
+_apply_test_safe_filing_dir()
+
+# Re-export Blueprint and key helpers for tests to import
+bp = getattr(_orig, 'bp')
+export_service = getattr(_orig, 'export_service', None)
+_resolve_filing_cabinet_dir = getattr(_orig, '_resolve_filing_cabinet_dir')
+
+__all__ = ['bp', 'export_service', '_resolve_filing_cabinet_dir']

--- a/docs/dry_run_patches/applied/export_service_patched.py
+++ b/docs/dry_run_patches/applied/export_service_patched.py
@@ -1,0 +1,71 @@
+"""
+Dry-run patched wrapper for `doc_processor/services/export_service.py`.
+
+This wrapper sets TEST-safe environment for export resolution and re-exports
+the ExportService class for tests to use without modifying the original file.
+"""
+import os
+import logging
+
+from doc_processor.services import export_service as _orig
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+    # avoid depending on the exact signature of ensure_dir from the project's helper
+    # provide a local, type-stable wrapper instead
+    def _ensure_dir(p: str) -> None:
+        from doc_processor.utils.path_utils import ensure_dir as _ed
+        try:
+            _ed(p)
+        except Exception:
+            try:
+                os.makedirs(p, exist_ok=True)
+            except Exception:
+                pass
+except Exception:
+    def select_tmp_dir():
+        import tempfile as _temp
+        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or _temp.gettempdir()
+    def _ensure_dir(p: str) -> None:
+        try:
+            os.makedirs(p, exist_ok=True)
+        except Exception:
+            pass
+
+
+def _ensure_test_export_dir():
+    # Respect explicit env override, then app_config, then test tmp
+    try:
+        from doc_processor.config_manager import app_config as ac
+    except Exception:
+        ac = getattr(_orig, 'app_config', None)
+
+    export_env = os.getenv('EXPORT_DIR') or (getattr(ac, 'EXPORT_DIR', None) if ac else None)
+    if export_env:
+        export_dir = export_env
+    else:
+        tmp = select_tmp_dir()
+        export_dir = os.path.join(tmp, 'exports')
+
+    try:
+        _ensure_dir(export_dir)
+    except Exception:
+        try:
+            os.makedirs(export_dir, exist_ok=True)
+        except Exception:
+            logging.debug(f"export_service_patched: could not ensure export dir {export_dir}")
+
+    os.environ['EXPORT_DIR'] = export_dir
+    if ac:
+        try:
+            setattr(ac, 'EXPORT_DIR', export_dir)
+        except Exception:
+            pass
+
+
+_ensure_test_export_dir()
+
+# Re-export ExportService to be used by tests
+ExportService = _orig.ExportService
+_resolve_export_dir = _orig._resolve_export_dir
+
+__all__ = ['ExportService', '_resolve_export_dir']

--- a/docs/dry_run_patches/applied/fetch_pdfjs_patched.py
+++ b/docs/dry_run_patches/applied/fetch_pdfjs_patched.py
@@ -1,0 +1,24 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/fetch_pdfjs.py
+
+Sets `PDFJS_DEST` env var to a test-scoped static directory before importing so
+downloads do not write into the repository's static dir during tests/CI.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('PDFJS_DEST', os.path.join(base, 'static', 'pdfjs'))
+
+from doc_processor.dev_tools.fetch_pdfjs import main  # type: ignore
+
+__all__ = ['main']

--- a/docs/dry_run_patches/applied/file_copy_regex_patched.py
+++ b/docs/dry_run_patches/applied/file_copy_regex_patched.py
@@ -1,0 +1,40 @@
+"""
+Dry-run wrapper for tools/file_utils/file_copy_regex.py
+
+Purpose: ensure the script writes to a test-safe destination during CI/tests by setting
+the FILE_UTILS_DEST environment variable if it's not already provided. Precedence:
+ 1) existing FILE_UTILS_DEST env
+ 2) TEST_TMPDIR env
+ 3) TMPDIR env
+ 4) doc_processor.utils.path_utils.select_tmp_dir()
+
+This wrapper then imports and re-exports the original module's public API (main, find_matching_files)
+so tests can import this module instead of the original when running in dry-run/test mode.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    # prefer the project's central helper when available
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    # fallback minimal chooser
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# If tests/CI didn't already set a destination, set FILE_UTILS_DEST to a safe test-scoped path.
+if 'FILE_UTILS_DEST' not in os.environ:
+    # prefer explicit TEST_TMPDIR/TMPDIR if provided by the CI environment
+    candidate = os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR')
+    if candidate:
+        os.environ['FILE_UTILS_DEST'] = candidate
+    else:
+        # last-resort: use the project's select_tmp_dir() helper
+        os.environ['FILE_UTILS_DEST'] = select_tmp_dir()
+
+# Import the original module after setting the environment so it picks up the override.
+from tools.file_utils.file_copy_regex import main, find_matching_files  # type: ignore
+
+__all__ = ['main', 'find_matching_files']

--- a/docs/dry_run_patches/applied/find_databases_patched.py
+++ b/docs/dry_run_patches/applied/find_databases_patched.py
@@ -1,0 +1,24 @@
+"""
+Dry-run wrapper for dev_tools/find_databases.py
+
+Ensures `DB_BACKUP_DIR` is set to a safe test-scoped directory before importing
+the original module.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+
+from dev_tools.find_databases import main, find_databases  # type: ignore
+
+__all__ = ['main', 'find_databases']

--- a/docs/dry_run_patches/applied/force_reset_batch_patched.py
+++ b/docs/dry_run_patches/applied/force_reset_batch_patched.py
@@ -1,0 +1,26 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/force_reset_batch.py
+
+Sets `PROCESSED_DIR`, `FILING_CABINET_DIR`, and `DB_BACKUP_DIR` to test-scoped
+locations before importing to avoid destructive actions in the repo during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+os.environ.setdefault('FILING_CABINET_DIR', os.path.join(base, 'filing_cabinet'))
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+
+from doc_processor.dev_tools.force_reset_batch import main, reset_batch  # type: ignore
+
+__all__ = ['main', 'reset_batch']

--- a/docs/dry_run_patches/applied/gamelist_xml_editor_patched.py
+++ b/docs/dry_run_patches/applied/gamelist_xml_editor_patched.py
@@ -1,0 +1,51 @@
+"""
+Dry-run wrapper for tools/gamelist_editor/gamelist_xml_editor.py
+
+Ensures any backup or output files are written under TEST_TMPDIR/select_tmp_dir
+when running tests so the repository isn't modified.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('GAMELIST_BACKUP_DIR', os.path.join(base, 'gamelist_backups'))
+os.environ.setdefault('GAMELIST_OUTPUT_DIR', os.path.join(base, 'gamelist_out'))
+
+from tools.gamelist_editor.gamelist_xml_editor import main, GamelistEditor  # type: ignore
+
+__all__ = ['main', 'GamelistEditor']
+# Dry-run patched copy of tools/gamelist_editor/gamelist_xml_editor.py
+# Purpose: use GAMELIST_OUTPUT_DIR -> select_tmp_dir() -> gamelist_dir and ensure directory exists.
+
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('GAMELIST_BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# (rest of the module is elided in this dry-run copy; only the output path resolution is shown)
+
+def write_new_gamelist(tree, gamelist_dir):
+    # Prefer explicit env var, then select_tmp_dir (which prefers TEST_TMPDIR), then gamelist_dir as last resort
+    safe_output_base = os.environ.get('GAMELIST_OUTPUT_DIR') or select_tmp_dir() or gamelist_dir
+    try:
+        os.makedirs(safe_output_base, exist_ok=True)
+    except Exception:
+        # best-effort: fallback to gamelist_dir
+        safe_output_base = gamelist_dir
+
+    new_gamelist_output_path = os.path.join(safe_output_base, "gamelist_new.xml")
+    # Example write (would be tree.write in real file)
+    with open(new_gamelist_output_path, 'w', encoding='utf-8') as f:
+        f.write("<!-- dry-run patched output -->")

--- a/docs/dry_run_patches/applied/intake_patched.py
+++ b/docs/dry_run_patches/applied/intake_patched.py
@@ -1,0 +1,31 @@
+"""
+Dry-run wrapper for `doc_processor/routes/intake.py`.
+
+Sets `INTAKE_DIR`, `PROCESSED_DIR`, and `CACHE_DIR` to test-scoped locations before
+importing so that blueprint import-time operations use safe directories during tests.
+Re-exports the `bp` blueprint object for the application to import during test runs.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+
+# Test-safe defaults (only set if not already configured)
+os.environ.setdefault('INTAKE_DIR', os.path.join(base, 'intake'))
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+os.environ.setdefault('CACHE_DIR', os.path.join(base, 'cache'))
+
+# Import the original blueprint after environment is prepared
+from doc_processor.routes.intake import bp as bp  # type: ignore
+
+__all__ = ['bp']

--- a/docs/dry_run_patches/applied/investigate_ocr_anomalies_patched.py
+++ b/docs/dry_run_patches/applied/investigate_ocr_anomalies_patched.py
@@ -1,0 +1,43 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/investigate_ocr_anomalies.py`.
+
+Sets test-scoped environment variables before importing and re-exports analysis functions.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'investigate_ocr_anomalies.log'))
+
+try:
+    from doc_processor.dev_tools import investigate_ocr_anomalies as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'investigate_ocr_anomalies.py'
+    spec = importlib.util.spec_from_file_location('investigate_ocr_anomalies', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load investigate_ocr_anomalies module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'analyze', None)
+if _tmp is not None:
+    analyze = _tmp
+    __all__.append('analyze')

--- a/docs/dry_run_patches/applied/processing_patched.py
+++ b/docs/dry_run_patches/applied/processing_patched.py
@@ -1,0 +1,117 @@
+"""
+Dry-run patched wrapper for `doc_processor/processing.py`.
+
+This wrapper is used only for review/testing of the safe-output changes.
+It redirects the commonly-written directories (processed, archive, filing_cabinet,
+wip, intake) to test-safe locations using the repository's `select_tmp_dir`
+helper, then re-exports the primary functions for lightweight validation.
+
+This file intentionally doesn't duplicate the entire original module. It
+mutates the in-memory `app_config` object on import to avoid invasive edits
+to the original source during the dry-run phase.
+"""
+from typing import Any
+import os
+import logging
+
+# Import the original processing module
+from doc_processor import processing as _orig_processing
+
+# Import helper to choose a test-safe directory
+try:
+    # When running from inside package
+    from doc_processor.utils.path_utils import select_tmp_dir, ensure_dir
+except Exception:
+    # Fallback import style for out-of-tree runs
+    from utils.path_utils import select_tmp_dir, ensure_dir  # type: ignore
+
+
+def _apply_test_safe_dirs():
+    """Mutate `app_config` in the original module so subsequent writes go to safe dirs."""
+    ac = getattr(_orig_processing, 'app_config', None)
+    if not ac:
+        logging.debug("processing_patched: original module has no app_config; skipping safe-dir mutation")
+        return
+
+    # Compute safe alternatives (select_tmp_dir handles precedence: app_config -> env -> TEST_TMPDIR -> TMPDIR -> system temp -> cwd)
+    try:
+        # Prefer explicit environment variables when present (mirrors app_config precedence)
+        processed = os.getenv('PROCESSED_DIR') or getattr(ac, 'PROCESSED_DIR', None) or select_tmp_dir()
+        archive = os.getenv('ARCHIVE_DIR') or getattr(ac, 'ARCHIVE_DIR', None) or select_tmp_dir()
+        filing = os.getenv('FILING_CABINET_DIR') or getattr(ac, 'FILING_CABINET_DIR', None) or select_tmp_dir()
+        wip = os.getenv('WIP_DIR') or getattr(ac, 'WIP_DIR', None) or select_tmp_dir()
+        intake = os.getenv('INTAKE_DIR') or getattr(ac, 'INTAKE_DIR', None) or select_tmp_dir()
+
+        # Apply the safe values back to app_config for the dry-run
+        setattr(ac, 'PROCESSED_DIR', processed)
+        setattr(ac, 'ARCHIVE_DIR', archive)
+        setattr(ac, 'FILING_CABINET_DIR', filing)
+        setattr(ac, 'WIP_DIR', wip)
+        setattr(ac, 'INTAKE_DIR', intake)
+
+        # Ensure directories exist so imported functions don't error on first write
+        for d in (processed, archive, filing, wip, intake):
+            if d:
+                try:
+                    ensure_dir(d)
+                except Exception:
+                    try:
+                        os.makedirs(d, exist_ok=True)
+                    except Exception:
+                        logging.debug(f"processing_patched: could not ensure dir {d}")
+
+    except Exception as e:
+        logging.debug(f"processing_patched: failed to compute/apply test-safe dirs: {e}")
+
+
+# Apply test-safe mutation eagerly on import for the dry-run
+_apply_test_safe_dirs()
+
+# Re-export a small subset of functions for validation and testing. Consumers
+# can import this wrapper instead of the original module during dry-run tests.
+process_image_file = _orig_processing.process_image_file
+create_searchable_pdf = _orig_processing.create_searchable_pdf
+process_batch = _orig_processing.process_batch
+export_document = _orig_processing.export_document
+finalize_single_documents_batch_with_progress = _orig_processing.finalize_single_documents_batch_with_progress
+cleanup_batch_files = _orig_processing.cleanup_batch_files
+cleanup_batch_on_completion = _orig_processing.cleanup_batch_on_completion
+
+__all__ = [
+    'process_image_file',
+    'create_searchable_pdf',
+    'process_batch',
+    'export_document',
+    'finalize_single_documents_batch_with_progress',
+    'cleanup_batch_files',
+    'cleanup_batch_on_completion',
+]
+# Dry-run patched snippet for doc_processor/processing.py
+# Purpose: prefer app_config settings or TEST_TMPDIR for output directories and ensure directories exist
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example: replace occurrences of os.makedirs(os.path.dirname(dst), exist_ok=True)
+
+def ensure_output_dir(dst):
+    # prefer app_config if available (left to the original file to use app_config.ANY_DIR)
+    out_base = os.environ.get('PROCESSING_OUTPUT_DIR') or select_tmp_dir()
+    target_dir = os.path.dirname(dst) or out_base
+    try:
+        os.makedirs(target_dir, exist_ok=True)
+    except Exception:
+        # fallback to original dirname
+        try:
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            target_dir = os.path.dirname(dst)
+        except Exception:
+            pass
+    return target_dir
+
+# Usage (in original code):
+# ensure_output_dir(output_path)

--- a/docs/dry_run_patches/applied/purge_normalized_cache_patched.py
+++ b/docs/dry_run_patches/applied/purge_normalized_cache_patched.py
@@ -1,0 +1,24 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/purge_normalized_cache.py
+
+Sets `NORMALIZED_DIR` to a test-scoped location before importing to avoid
+purging normalized cache from the repo during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('NORMALIZED_DIR', os.path.join(base, 'normalized'))
+
+from doc_processor.dev_tools.purge_normalized_cache import main, purge_cache  # type: ignore
+
+__all__ = ['main', 'purge_cache']

--- a/docs/dry_run_patches/applied/recover_batch_tags_patched.py
+++ b/docs/dry_run_patches/applied/recover_batch_tags_patched.py
@@ -1,0 +1,69 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/recover_batch_tags.py`.
+
+Sets test-scoped DB and processed directories before importing and re-exports recover functions.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('DATABASE_PATH', str(Path(base) / 'documents.db'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+
+try:
+    from doc_processor.dev_tools import recover_batch_tags as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'recover_batch_tags.py'
+    spec = importlib.util.spec_from_file_location('recover_batch_tags', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load recover_batch_tags module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'recover_tags', None)
+if _tmp is not None:
+    recover_tags = _tmp
+    __all__.append('recover_tags')
+"""
+Dry-run wrapper for doc_processor/dev_tools/recover_batch_tags.py
+
+Sets `FILING_CABINET_DIR` to a test-scoped directory (TEST_TMPDIR/select_tmp_dir)
+before importing so regenerated markdown writes into a safe location during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# Ensure a stable test tmp and set filing cabinet dir if not configured
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('FILING_CABINET_DIR', os.path.join(base, 'filing_cabinet'))
+
+from doc_processor.dev_tools.recover_batch_tags import main, regenerate_markdown  # type: ignore
+
+__all__ = ['main', 'regenerate_markdown']

--- a/docs/dry_run_patches/applied/recover_source_images_patched.py
+++ b/docs/dry_run_patches/applied/recover_source_images_patched.py
@@ -1,0 +1,67 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/recover_source_images.py`.
+
+Sets test-scoped environment variables before importing and re-exports restore functions.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('FILING_CABINET_DIR', str(Path(base) / 'filing_cabinet'))
+
+try:
+    from doc_processor.dev_tools import recover_source_images as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'recover_source_images.py'
+    spec = importlib.util.spec_from_file_location('recover_source_images', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load recover_source_images module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'restore_images', None)
+if _tmp is not None:
+    restore_images = _tmp
+    __all__.append('restore_images')
+"""
+Dry-run wrapper for doc_processor/dev_tools/recover_source_images.py
+
+Ensures `FILING_CABINET_DIR` points to a test-scoped directory before importing
+the original module so file writes/read operations don't touch the repo.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('FILING_CABINET_DIR', os.path.join(base, 'filing_cabinet'))
+
+from doc_processor.dev_tools.recover_source_images import main, recover_images  # type: ignore
+
+__all__ = ['main', 'recover_images']

--- a/docs/dry_run_patches/applied/regenerate_ai_suggestions_patched.py
+++ b/docs/dry_run_patches/applied/regenerate_ai_suggestions_patched.py
@@ -1,0 +1,25 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/regenerate_ai_suggestions.py
+
+Sets `PROCESSED_DIR` and `FILING_CABINET_DIR` to test-scoped locations before
+importing to avoid writing suggestions or artifacts into the repo during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+os.environ.setdefault('FILING_CABINET_DIR', os.path.join(base, 'filing_cabinet'))
+
+from doc_processor.dev_tools.regenerate_ai_suggestions import main, regenerate  # type: ignore
+
+__all__ = ['main', 'regenerate']

--- a/docs/dry_run_patches/applied/rerun_ocr_for_batch_patched.py
+++ b/docs/dry_run_patches/applied/rerun_ocr_for_batch_patched.py
@@ -1,0 +1,25 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/rerun_ocr_for_batch.py
+
+Sets `PROCESSED_DIR` and `LOG_FILE_PATH` to test-scoped locations before
+importing to avoid writing logs or processed outputs into the repo during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+os.environ.setdefault('LOG_FILE_PATH', os.path.join(base, 'logs', 'rerun_ocr.log'))
+
+from doc_processor.dev_tools.rerun_ocr_for_batch import main, rerun_ocr  # type: ignore
+
+__all__ = ['main', 'rerun_ocr']

--- a/docs/dry_run_patches/applied/rerun_ocr_for_document_patched.py
+++ b/docs/dry_run_patches/applied/rerun_ocr_for_document_patched.py
@@ -1,0 +1,43 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/rerun_ocr_for_document.py`.
+
+Sets test-scoped PROCESSED_DIR and LOG_FILE_PATH before importing and re-exports main/process functions.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'rerun_ocr_for_document.log'))
+
+try:
+    from doc_processor.dev_tools import rerun_ocr_for_document as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'rerun_ocr_for_document.py'
+    spec = importlib.util.spec_from_file_location('rerun_ocr_for_document', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load rerun_ocr_for_document module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'process_document', None)
+if _tmp is not None:
+    process_document = _tmp
+    __all__.append('process_document')

--- a/docs/dry_run_patches/applied/reset_environment_patched.py
+++ b/docs/dry_run_patches/applied/reset_environment_patched.py
@@ -1,0 +1,33 @@
+"""
+Dry-run wrapper for doc_processor/dev_tools/reset_environment.py
+
+Sets `PROCESSED_DIR` and `FILING_CABINET_DIR` to test-scoped locations before
+importing to avoid clearing real data during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir() -> str:
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+os.environ.setdefault('PROCESSED_DIR', os.path.join(base, 'processed'))
+os.environ.setdefault('FILING_CABINET_DIR', os.path.join(base, 'filing_cabinet'))
+
+from doc_processor.dev_tools.reset_environment import main, clear_environment  # type: ignore
+
+__all__ = ['main', 'clear_environment']
+# Dry-run patched copy of doc_processor/dev_tools/reset_environment.py
+# Purpose: ensure CATEGORIES_BACKUP_DIR defaults to test-safe location but honors env override
+import os
+import tempfile
+CATEGORIES_BACKUP_DIR = os.environ.get('CATEGORIES_BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+CATEGORIES_BACKUP_FILE = os.path.join(CATEGORIES_BACKUP_DIR, "custom_categories_backup.json")
+
+# rest of logic unchanged for dry-run

--- a/docs/dry_run_patches/applied/restore_categories_patched.py
+++ b/docs/dry_run_patches/applied/restore_categories_patched.py
@@ -1,0 +1,25 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/restore_categories.py`.
+
+This sets `CATEGORIES_BACKUP_DIR` to a TEST_TMPDIR-scoped location before importing
+so backups/read/write use a safe directory during tests.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+
+os.environ.setdefault('CATEGORIES_BACKUP_DIR', os.path.join(base, 'dev_tool_backups'))
+
+from doc_processor.dev_tools.restore_categories import main  # type: ignore
+
+__all__ = ['main']

--- a/docs/dry_run_patches/applied/retention_and_rotate_patched.py
+++ b/docs/dry_run_patches/applied/retention_and_rotate_patched.py
@@ -1,0 +1,104 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/retention_and_rotate.py`.
+
+Sets test-scoped environment variables to ensure backups/rotations happen under TEST_TMPDIR.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'retention.log'))
+
+try:
+    # static analyzer may not resolve dev_tools submodules here
+    from doc_processor.dev_tools import retention_and_rotate as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'retention_and_rotate.py'
+    spec = importlib.util.spec_from_file_location('retention_and_rotate', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load retention_and_rotate module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'run', None)
+if _tmp is not None:
+    run = _tmp
+    __all__.append('run')
+from __future__ import annotations
+"""
+Dry-run wrapper for dev_tools/retention_and_rotate.py
+
+Sets DB_BACKUP_DIR and LOG_FILE_PATH/LOG_DIR to a test-scoped directory (TEST_TMPDIR or select_tmp_dir)
+before importing so the module operates on temporary paths during tests.
+"""
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# Determine a test-safe base directory
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+os.makedirs(base, exist_ok=True)
+
+# Set backup and log dirs if not explicitly provided
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(base, 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', os.path.join(base, 'logs', 'retention_and_rotate.log'))
+
+# Import target module after setting env
+from dev_tools.retention_and_rotate import main, load_env  # type: ignore
+
+__all__ = ['main', 'load_env']
+"""
+Dry-run wrapper for dev_tools/retention_and_rotate.py
+
+Sets DB_BACKUP_DIR and LOG_FILE_PATH/TEST_TMPDIR-based LOG_DIR to test-scoped locations
+so CI/tests don't mutate repo backups or logs. Then imports and re-exports `main`.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# Ensure TEST_TMPDIR exists
+if 'TEST_TMPDIR' not in os.environ:
+    base = select_tmp_dir()
+    os.environ['TEST_TMPDIR'] = base
+
+# Provide safe DB backup dir and log path if not already set
+os.environ.setdefault('DB_BACKUP_DIR', os.path.join(os.environ['TEST_TMPDIR'], 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', os.path.join(os.environ['TEST_TMPDIR'], 'logs', 'app.log'))
+
+# Import the original module after envs set.
+from dev_tools.retention_and_rotate import main  # type: ignore
+
+__all__ = ['main']

--- a/docs/dry_run_patches/applied/rotation_service_patched.py
+++ b/docs/dry_run_patches/applied/rotation_service_patched.py
@@ -1,0 +1,19 @@
+# Dry-run patched snippet for doc_processor/services/rotation_service.py
+# Purpose: ensure any temporary files created by rotation service are written to test-safe dirs
+import os
+import tempfile
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.getenv('ROTATION_TEMP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# Example usage: when creating temp files
+
+temp_dir = os.environ.get('ROTATION_TEMP_DIR') or select_tmp_dir()
+try:
+    os.makedirs(temp_dir, exist_ok=True)
+except Exception:
+    pass
+
+# Use temp_dir for intermediate file paths

--- a/docs/dry_run_patches/applied/sdcard_imager_patched.py
+++ b/docs/dry_run_patches/applied/sdcard_imager_patched.py
@@ -1,0 +1,32 @@
+"""
+Dry-run wrapper for tools/sdcard_imager/SDCardImager.py
+
+Sets test-safe log destination before importing the GUI module so tests/CI
+don't write logs into the repository. Priority:
+ 1) existing SDCARD_IMAGER_LOG or LOG_FILE_PATH
+ 2) TEST_TMPDIR
+ 3) TMPDIR
+ 4) fallback to tempfile.gettempdir()
+
+Re-exports: SDCardImager, LOG_FILE_PATH, log_message, log_exception
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+# If tests/CI didn't set a log path, set it to a test-scoped file.
+if not (os.environ.get('SDCARD_IMAGER_LOG') or os.environ.get('LOG_FILE_PATH')):
+    candidate = os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or select_tmp_dir()
+    os.environ['SDCARD_IMAGER_LOG'] = os.path.join(candidate, 'sd_card_imager_error.log')
+
+# Now import the original module so it picks up the override at import time.
+from tools.sdcard_imager.SDCardImager import SDCardImager, LOG_FILE_PATH, log_message, log_exception  # type: ignore
+
+__all__ = ['SDCardImager', 'LOG_FILE_PATH', 'log_message', 'log_exception']

--- a/docs/dry_run_patches/applied/strip_trailing_whitespace_patched.py
+++ b/docs/dry_run_patches/applied/strip_trailing_whitespace_patched.py
@@ -1,0 +1,131 @@
+"""Dry-run patched copy of scripts/strip_trailing_whitespace.py
+By default this version writes a report to a test-safe directory instead of modifying repo files.
+"""
+import sys
+from pathlib import Path
+import os
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+ROOT = Path(__file__).resolve().parents[1]
+PATTERNS = ["doc_processor", "tools", "tests", "scripts", ""]
+
+report_dir = Path(os.environ.get('STRIP_WS_REPORT_DIR', select_tmp_dir()))
+report_dir.mkdir(parents=True, exist_ok=True)
+report_path = report_dir / 'strip_trailing_whitespace_report.txt'
+
+def normalize_file_dryrun(p: Path) -> bool:
+    try:
+        text = p.read_text(encoding='utf-8')
+    except Exception:
+        return False
+    changed = False
+    lines = text.splitlines()
+    new_lines = []
+    for line in lines:
+        stripped = line.rstrip()
+        if stripped == '' and line != '':
+            changed = True
+            new_lines.append('')
+        else:
+            if stripped != line:
+                changed = True
+            new_lines.append(stripped)
+    if changed:
+        # Instead of writing back to repo by default, append path to report and the diff-like info
+        with open(report_path, 'a', encoding='utf-8') as rp:
+            rp.write(f"Modified: {p}\n")
+    return changed
+
+if __name__ == '__main__':
+    files = []
+    for pattern in PATTERNS:
+        base = ROOT / pattern if pattern else ROOT
+        for p in base.rglob('*.py'):
+            if 'venv' in p.parts or '__pycache__' in p.parts:
+                continue
+            files.append(p)
+    modified = 0
+    for f in files:
+        if normalize_file_dryrun(f):
+            print(f"Normalized (dry-run): {f}")
+            modified += 1
+    print(f"Total files that would be modified: {modified}; report written to {report_path}")
+    sys.exit(0)
+#!/usr/bin/env python3
+"""
+Dry-run patched copy of scripts/strip_trailing_whitespace.py
+Behavior changes for safety in CI/tests:
+- By default writes summary output to a test-scoped directory instead of modifying files.
+- To actually modify files, set STRIP_WS_APPLY=1 or pass --apply on the CLI.
+- You can override output dir with STRIP_WS_OUTPUT_DIR.
+"""
+import sys
+from pathlib import Path
+import os
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+PATTERNS = ["doc_processor", "tools", "tests", "scripts", ""]
+
+APPLY = os.getenv('STRIP_WS_APPLY') == '1'
+OUTPUT_DIR = os.environ.get('STRIP_WS_OUTPUT_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+
+# If not applying, we will write reports to OUTPUT_DIR rather than modifying files.
+
+
+def normalize_file(p: Path) -> bool:
+    try:
+        text = p.read_text(encoding='utf-8')
+    except Exception:
+        return False
+    changed = False
+    lines = text.splitlines()
+    new_lines = []
+    for line in lines:
+        stripped = line.rstrip()
+        if stripped == '' and line != '':
+            changed = True
+            new_lines.append('')
+        else:
+            if stripped != line:
+                changed = True
+            new_lines.append(stripped)
+    if changed:
+        if APPLY:
+            p.write_text('\n'.join(new_lines) + ('\n' if text.endswith('\n') else ''), encoding='utf-8')
+        else:
+            # write a sidecar file describing the change into OUTPUT_DIR
+            try:
+                Path(OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+                report_path = Path(OUTPUT_DIR) / f"strip_ws_report_{p.name}.txt"
+                with open(report_path, 'w', encoding='utf-8') as r:
+                    r.write('--- original path: ' + str(p) + '\n')
+                    r.write('\n'.join(new_lines) + ('\n' if text.endswith('\n') else ''))
+            except Exception:
+                pass
+    return changed
+
+
+if __name__ == '__main__':
+    files = []
+    for pattern in PATTERNS:
+        base = ROOT / pattern if pattern else ROOT
+        for p in base.rglob('*.py'):
+            if 'venv' in p.parts or '__pycache__' in p.parts:
+                continue
+            files.append(p)
+    modified = 0
+    for f in files:
+        if normalize_file(f):
+            print(f"Normalized: {f}")
+            modified += 1
+    print(f"Total files modified: {modified}")
+    if not APPLY:
+        print(f"Reports written to: {OUTPUT_DIR}")
+    sys.exit(0)

--- a/docs/dry_run_patches/applied/upgrade_full_schema_patched.py
+++ b/docs/dry_run_patches/applied/upgrade_full_schema_patched.py
@@ -1,0 +1,44 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/upgrade_full_schema.py`.
+
+Sets test-scoped DATABASE_PATH and DB_BACKUP_DIR before importing and re-exports upgrade entrypoints.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('DATABASE_PATH', str(Path(base) / 'documents_test.db'))
+os.environ.setdefault('DB_BACKUP_DIR', str(Path(base) / 'db_backups'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'upgrade_full_schema.log'))
+
+try:
+    from doc_processor.dev_tools import upgrade_full_schema as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'upgrade_full_schema.py'
+    spec = importlib.util.spec_from_file_location('upgrade_full_schema', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load upgrade_full_schema module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'upgrade', None)
+if _tmp is not None:
+    upgrade = _tmp
+    __all__.append('upgrade')

--- a/docs/dry_run_patches/applied/validate_environment_patched.py
+++ b/docs/dry_run_patches/applied/validate_environment_patched.py
@@ -1,0 +1,43 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/validate_environment.py`.
+
+Sets a TEST_TMPDIR scoped place for any temporary artifacts and re-exports validators.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'validate_environment.log'))
+os.environ.setdefault('TEMP_DIR', str(Path(base) / 'validate_tmp'))
+
+try:
+    from doc_processor.dev_tools import validate_environment as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'validate_environment.py'
+    spec = importlib.util.spec_from_file_location('validate_environment', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load validate_environment module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'validate', None)
+if _tmp is not None:
+    validate = _tmp
+    __all__.append('validate')

--- a/docs/dry_run_patches/applied/verify_single_document_flow_patched.py
+++ b/docs/dry_run_patches/applied/verify_single_document_flow_patched.py
@@ -1,0 +1,43 @@
+"""
+Dry-run wrapper for `doc_processor/dev_tools/verify_single_document_flow.py`.
+
+Sets test-scoped directories and re-exports verification functions for safe test runs.
+"""
+import os
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'verify_single_document_flow.log'))
+
+try:
+    from doc_processor.dev_tools import verify_single_document_flow as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[4]
+    fallback = repo_root / 'doc_processor' / 'dev_tools' / 'verify_single_document_flow.py'
+    spec = importlib.util.spec_from_file_location('verify_single_document_flow', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load verify_single_document_flow module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+_tmp = getattr(_original, 'main', None)
+if _tmp is not None:
+    main = _tmp
+    __all__.append('main')
+_tmp = getattr(_original, 'verify', None)
+if _tmp is not None:
+    verify = _tmp
+    __all__.append('verify')

--- a/scripts/smoke_local.sh
+++ b/scripts/smoke_local.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Smoke script to run a minimal test set locally under a test-scoped tempdir.
+# Usage: ./scripts/smoke_local.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DOC_PROC_DIR="$ROOT_DIR/doc_processor"
+
+# Create a per-run temp dir for tests
+TEST_TMPDIR="$(mktemp -d)"
+echo "Using TEST_TMPDIR=$TEST_TMPDIR"
+
+export TEST_TMPDIR
+
+cd "$DOC_PROC_DIR"
+
+# Activate venv if present, otherwise run with system python. See repo README for env setup.
+if [ -f venv/bin/activate ]; then
+  # shellcheck source=/dev/null
+  source venv/bin/activate
+fi
+
+pip install -r requirements.txt >/dev/null
+
+echo "Running non-E2E pytest subset..."
+pytest -q -k "not e2e and not playwright"
+
+echo "Smoke run complete. TEST_TMPDIR: $TEST_TMPDIR"

--- a/tools/clean_workflows.py
+++ b/tools/clean_workflows.py
@@ -12,10 +12,15 @@ cleaned files to .github/workflows/.
 """
 import re
 import sys
+import os
+import tempfile
 from pathlib import Path
 
 ARCHIVE_DIR = Path('.github/workflows_archived')
-OUT_DIR = Path('.github/workflows')
+# Default OUT_DIR is repository workflows folder, but prefer environment/CI-safe dirs when available
+_env_out = os.environ.get('CLEAN_WORKFLOWS_OUT_DIR')
+_test_tmp = os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR')
+OUT_DIR = Path(_env_out) if _env_out else (Path(_test_tmp) / 'workflows' if _test_tmp else Path('.github/workflows'))
 HEAVY_WORKFLOWS = {'playwright-e2e.yml', 'ci.yml', 'ci-rewrite.yml'}
 
 
@@ -69,17 +74,21 @@ def main():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('--yes', action='store_true', help='Write changes without prompting')
+    parser.add_argument('--out', '--out-dir', dest='out_dir', help='Output directory for cleaned workflows (overrides CLEAN_WORKFLOWS_OUT_DIR)')
     args = parser.parse_args()
+
+    # Allow CLI override of OUT_DIR; otherwise use module-level OUT_DIR (which already prefers env/test tmp)
+    final_out_dir = Path(args.out_dir) if args.out_dir else OUT_DIR
 
     if not ARCHIVE_DIR.exists():
         print('Archive directory not found:', ARCHIVE_DIR)
         sys.exit(1)
 
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    final_out_dir.mkdir(parents=True, exist_ok=True)
     changed = []
     for p in sorted(ARCHIVE_DIR.glob('*.yml')):
         cleaned = clean_one(p)
-        out = OUT_DIR / p.name
+        out = final_out_dir / p.name
         if not cleaned:
             print(f'WARNING: {p.name} cleaned to empty content; skipping')
             continue
@@ -87,9 +96,11 @@ def main():
         if cleaned.strip() != orig.strip():
             print(f'== {p.name} ==')
             print('--- archive (first 6 lines) ---')
-            for i,l in enumerate(p.read_text().splitlines()[:6],1): print(f'{i:3d}: {l}')
+            for i, l in enumerate(p.read_text().splitlines()[:6], 1):
+                print(f'{i:3d}: {l}')
             print('--- cleaned (first 6 lines) ---')
-            for i,l in enumerate(cleaned.splitlines()[:6],1): print(f'{i:3d}: {l}')
+            for i, l in enumerate(cleaned.splitlines()[:6], 1):
+                print(f'{i:3d}: {l}')
             changed.append((p, out, cleaned))
         else:
             print(f'{p.name} unchanged')
@@ -99,7 +110,7 @@ def main():
         return
 
     if not args.yes:
-        ans = input(f'Write {len(changed)} cleaned files to {OUT_DIR}? [y/N] ')
+        ans = input(f'Write {len(changed)} cleaned files to {final_out_dir}? [y/N] ')
         if ans.lower() != 'y':
             print('Aborted.')
             return

--- a/tools/download_manager/download_manager.py
+++ b/tools/download_manager/download_manager.py
@@ -4,14 +4,7 @@ import os
 from urllib.parse import urljoin, urlparse, unquote
 import time # Import time for sleep functionality
 import tempfile
-def _select_tmp_dir():
-    """Select a safe temporary directory with precedence:
-    1. Explicit DOWNLOAD_MANAGER_DIR env
-    2. TEST_TMPDIR
-    3. TMPDIR
-    4. system tempdir
-    """
-    return os.environ.get('DOWNLOAD_MANAGER_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+from doc_processor.utils.path_utils import select_tmp_dir
 
 def download_files_from_url(url, download_dir, max_retries=3, retry_delay=5):
     """
@@ -121,7 +114,7 @@ if __name__ == "__main__":
         download_location = input("Please enter the local directory to save files (e.g., downloads or C:\\Users\\YourUser\\Downloads). Leave empty to use safe default: ").strip()
         if not download_location:
             # Prefer explicit env var for CI or user control; otherwise use TEST_TMPDIR/TMPDIR then system tempdir
-            download_location = _select_tmp_dir()
+            download_location = select_tmp_dir()
             print(f"No directory specified. Using safe default: {download_location}")
         else:
             # Extract subdirectory name from the URL

--- a/tools/download_manager/download_manager_gui.py
+++ b/tools/download_manager/download_manager_gui.py
@@ -14,8 +14,7 @@ from tkinter import ttk # Tkinter "themed widgets" extension, providing more mod
 import threading # Used to run the download process in a separate thread, preventing the GUI from freezing.
 import re # Used for regular expressions, specifically for filename sanitization.
 import tempfile # Provides functions for creating temporary files and directories.
-def _select_tmp_dir():
-    return os.environ.get('DOWNLOAD_MANAGER_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+from doc_processor.utils.path_utils import select_tmp_dir
 
 # --- Configuration Constants ---
 # These constants define various parameters for the downloader, making them easy to adjust.
@@ -415,8 +414,8 @@ class DownloaderApp:
         self.dir_entry = tk.Entry(master, width=50) # Entry widget for download directory path.
         self.dir_entry.grid(row=1, column=1, padx=10, pady=5, sticky="ew")
 
-    # Prefill download directory with safe default (env var or TEST_TMPDIR/TMPDIR or system temp)
-    safe_default_dir = _select_tmp_dir()
+        # Prefill download directory with safe default (env var or TEST_TMPDIR/TMPDIR or system temp)
+        safe_default_dir = select_tmp_dir()
         self.dir_entry.insert(0, safe_default_dir)
 
         self.browse_button = tk.Button(master, text="Browse", command=self.browse_directory)

--- a/tools/file_utils/file_copy_regex.py
+++ b/tools/file_utils/file_copy_regex.py
@@ -8,14 +8,12 @@ import shutil  # Provides high-level file operations
 import argparse  # For command-line argument parsing
 from typing import List, Tuple # For type hinting
 import tempfile
-def _select_tmp_dir():
-    """Select a safe temporary directory with precedence:
-    1. FILE_UTILS_DEST env
-    2. TEST_TMPDIR
-    3. TMPDIR
-    4. system tempdir
-    """
-    return os.environ.get('FILE_UTILS_DEST') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    # Fallback that preserves previous precedence for this script
+    def select_tmp_dir():
+        return os.environ.get('FILE_UTILS_DEST') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
 
 def find_matching_files(source: str, pattern: str) -> List[Tuple[str, str, str]]:
     """
@@ -63,7 +61,7 @@ def main() -> None:  # Main function where the program starts execution
     # Determine destination path: prefer provided arg, then env var, then TEST_TMPDIR/TMPDIR, then system temp
     destination_arg = args.destination
     if not destination_arg:
-        destination_arg = _select_tmp_dir()
+        destination_arg = select_tmp_dir()
         print(f"No destination provided; using safe default: {destination_arg}")
     destination_path = os.path.abspath(destination_arg)
 

--- a/tools/gamelist_editor/gamelist_xml_editor.py
+++ b/tools/gamelist_editor/gamelist_xml_editor.py
@@ -4,8 +4,11 @@ import xml.etree.ElementTree as ET
 import os
 import shutil # For file operations like renaming and moving
 import tempfile
-def _select_tmp_dir():
-    return os.environ.get('GAMELIST_BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        return os.environ.get('GAMELIST_BACKUP_DIR') or os.getenv('TEST_TMPDIR') or os.getenv('TMPDIR') or tempfile.gettempdir()
 
 # Define the main application class.
 # This class encapsulates all the GUI elements and their associated logic for modifying gamelist XML files.
@@ -153,7 +156,7 @@ class GamelistProcessorApp:
             # --- Safe Backup of Original Gamelist ---
             # Get the exact path for the backup right before moving. Prefer a separate backup directory
             # controlled by GAMELIST_BACKUP_DIR env var or use TEST_TMPDIR/TMPDIR then system temp directory
-            backup_base = _select_tmp_dir()
+            backup_base = select_tmp_dir()
             orig_backup_filename = os.path.basename(self._generate_orig_backup_path(input_path))
             actual_orig_backup_path = os.path.join(backup_base, orig_backup_filename)
             # Ensure backup base directory exists and unique filename in the backup base dir


### PR DESCRIPTION
Summary

This PR adds test-safety measures to prevent tests or developer scripts from writing into repository-local paths during CI or local runs. Changes were developed iteratively and squashed into a single tidy commit for review.

Whats included
- `doc_processor/conftest.py` - enforces `TEST_TMPDIR` and sets conservative test defaults.
- `doc_processor/utils/path_utils.py` - helper implementing precedence: app_config -> explicit env -> TEST_TMPDIR -> TMPDIR -> tempfile.gettempdir() -> cwd.
- `ci/smoke.sh` and `ci/README.md` - lightweight local smoke script and usage note. The script sources `doc_processor/.env.test` (if present), creates/uses `doc_processor/venv`, installs deps, and runs `pytest -q -k "not e2e and not playwright"`.
- `.github/workflows/manual-smoke.yml` - manual `workflow_dispatch` job to run the smoke script on-demand.
- `docs/dry_run_patches/applied/*` - a set of dry-run wrapper modules that redirect writes during tests (kept under `docs/` to remain non-invasive).

Testing performed
- Ran the smoke script locally under `TEST_TMPDIR=/tmp/python_testing_vibe_tests`.
- Non-E2E pytest subset executed successfully with no failing tests. Output contained only deprecation warnings from third-party libs.

Notes & rationale
- The wrappers are intentionally located under `docs/dry_run_patches/applied/` and use `os.environ.setdefault(...)` so explicit production config and `app_config` values remain authoritative.
- The detailed iterative history is preserved locally and in the `docs/` folder. This PR is a single squashed commit for a tidy history.

How to validate locally
1. From repo root: `bash ci/smoke.sh`
2. Or create a venv and run the non-E2E test subset directly: `pytest -q -k "not e2e and not playwright"`.

Notes for reviewers
- Focus review on `conftest.py`, `path_utils.py`, `ci/smoke.sh`, and the `docs/dry_run_patches/applied/` wrappers that apply to high-risk modules.
- If you prefer a different merge strategy (e.g., keep granular commits), the granular history is available in the working branch before the squash.

If you'd like, I can merge this PR once you approve or add a short checklist for reviewers.