### PR TITLE
chore(tests): add dry-run wrappers for remaining audit targets (batch-11)

### DIFF
--- a/docs/dry_run_patches/applied/api_patched.py
+++ b/docs/dry_run_patches/applied/api_patched.py
@@ -1,0 +1,38 @@
+"""
+Dry-run wrapper for `doc_processor/routes/api.py`.
+
+Ensures test-scoped envs before importing API route module.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import importlib
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'routes_api.log'))
+os.environ.setdefault('INTAKE_DIR', str(Path(base) / 'intake'))
+
+try:
+    from doc_processor.routes import api as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[3]
+    fallback = repo_root / 'doc_processor' / 'routes' / 'api.py'
+    spec = importlib.util.spec_from_file_location('doc_processor.routes.api', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load api module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []

--- a/docs/dry_run_patches/applied/batch_patched.py
+++ b/docs/dry_run_patches/applied/batch_patched.py
@@ -1,0 +1,48 @@
+"""
+Dry-run wrapper for `doc_processor/routes/batch.py`.
+
+This wrapper ensures test-scoped directories (via TEST_TMPDIR) are set
+before importing the real routes module so any write operations during
+tests are redirected to a safe location.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import importlib
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+# Set common directories to test-scoped locations if not already set
+os.environ.setdefault('INTAKE_DIR', str(Path(base) / 'intake'))
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('FILING_CABINET_DIR', str(Path(base) / 'filing_cabinet'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'routes_batch.log'))
+
+try:
+    # prefer package import
+    from doc_processor.routes import batch as _original  # type: ignore
+except Exception:
+    # fallback: load by file path from repo
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[3]
+    fallback = repo_root / 'doc_processor' / 'routes' / 'batch.py'
+    spec = importlib.util.spec_from_file_location('doc_processor.routes.batch', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load batch module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+for name in ('bp','blueprint'):
+    if hasattr(_original, name):
+        __all__.append(name)

--- a/docs/dry_run_patches/applied/document_processor_patched.py
+++ b/docs/dry_run_patches/applied/document_processor_patched.py
@@ -1,0 +1,44 @@
+"""
+Dry-run wrapper for `archive/legacy/Document_Scanner_Gemini_outdated/document_processor.py`.
+
+Redirects any archive/output paths to TEST_TMPDIR before importing the legacy
+document processor module so running it during tests won't modify repo files.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import importlib
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('ARCHIVE_OUTPUT_DIR', str(Path(base) / 'archive_output'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'legacy_document_processor.log'))
+
+# Attempt to import via package path first; otherwise load from archive path
+try:
+    # Not a package in main code; prefer file import
+    raise ImportError
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[3]
+    fallback = repo_root / 'archive' / 'legacy' / 'Document_Scanner_Gemini_outdated' / 'document_processor.py'
+    spec = importlib.util.spec_from_file_location('legacy.document_processor', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load legacy document_processor module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []
+for candidate in ('main','process','run'):
+    if hasattr(_original, candidate):
+        __all__.append(candidate)

--- a/docs/dry_run_patches/applied/manipulation_patched.py
+++ b/docs/dry_run_patches/applied/manipulation_patched.py
@@ -1,0 +1,41 @@
+"""
+Dry-run wrapper for `doc_processor/routes/manipulation.py`.
+
+Redirects file-output related envs to `TEST_TMPDIR` before importing
+the real module so tests won't write into repo-scoped locations.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import importlib
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+os.environ.setdefault('INTAKE_DIR', str(Path(base) / 'intake'))
+os.environ.setdefault('FILING_CABINET_DIR', str(Path(base) / 'filing_cabinet'))
+os.environ.setdefault('LOG_FILE_PATH', str(Path(base) / 'routes_manipulation.log'))
+
+try:
+    from doc_processor.routes import manipulation as _original  # type: ignore
+except Exception:
+    import importlib.util
+    repo_root = Path(__file__).resolve().parents[3]
+    fallback = repo_root / 'doc_processor' / 'routes' / 'manipulation.py'
+    spec = importlib.util.spec_from_file_location('doc_processor.routes.manipulation', str(fallback))
+    if spec is None or spec.loader is None:
+        raise ImportError('Could not load manipulation module spec for dry-run wrapper')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    _original = mod
+
+__all__ = []

--- a/docs/dry_run_patches/applied/run_local_e2e_patched.py
+++ b/docs/dry_run_patches/applied/run_local_e2e_patched.py
@@ -1,0 +1,37 @@
+"""
+Dry-run wrapper for `scripts/run_local_e2e.sh`.
+
+This wrapper sets `TEST_TMPDIR` and related envs and then invokes the
+original shell script using `subprocess` so it runs in a safe test-scoped
+environment.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+try:
+    from doc_processor.utils.path_utils import select_tmp_dir
+except Exception:
+    def select_tmp_dir():
+        import tempfile
+        return os.environ.get('TEST_TMPDIR') or os.environ.get('TMPDIR') or tempfile.gettempdir()
+
+base = os.environ.get('TEST_TMPDIR') or select_tmp_dir()
+Path(base).mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault('TEST_TMPDIR', base)
+os.environ.setdefault('INTAKE_DIR', str(Path(base) / 'intake'))
+os.environ.setdefault('PROCESSED_DIR', str(Path(base) / 'processed'))
+
+def main(argv=None) -> int:
+    repo_root = Path(__file__).resolve().parents[3]
+    script = repo_root / 'scripts' / 'run_local_e2e.sh'
+    if not script.exists():
+        raise FileNotFoundError(f'Original script not found: {script}')
+    cmd = [str(script)] + (argv or [])
+    return subprocess.call(cmd, env=os.environ)
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Pre-wrap tag: pre-wrap-devtools-batch-11\n\nThis PR adds dry-run wrappers redirecting outputs to TEST_TMPDIR for the remaining audit targets identified in docs/output_path_audit.json. Smoke tests were run locally before opening the PR.