### PR TITLE
chore: add CODEOWNERS for CI and key areas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS file for Python_Testing_Vibe
+# Format: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for repository-level concerns
+*       @TaintedHorizon
+
+# CI and workflows
+.github/workflows/*    @TaintedHorizon
+
+# doc_processor area
+doc_processor/**       @TaintedHorizon
+
+# Release/packaging and scripts
+scripts/**             @TaintedHorizon
+dev_tools/**           @TaintedHorizon


### PR DESCRIPTION
Add a `CODEOWNERS` file to assign ownership for CI, `doc_processor`, and scripts/dev_tools. This is a small housekeeping PR that helps route reviews and approvals for the areas changed during the history-rewrite work.