### PR TITLE
Docs: add FAST_TEST_MODE note to CONTRIBUTING-NOTES

### DIFF
--- a/doc_processor/CONTRIBUTING-NOTES.md
+++ b/doc_processor/CONTRIBUTING-NOTES.md
@@ -7,3 +7,5 @@ This small file points to repository-level contributing guidance relevant to the
 - Project-level contributor summary: `docs/CONTRIBUTING-README.md`
 
 If you're contributing runtime changes (routes, processing, DB changes), follow `doc_processor/CONTRIBUTING.md` and add tests where practical.
+
+Note: For fast local test runs you can set `FAST_TEST_MODE=1` to skip heavy binary deps (OCR, PyMuPDF, etc.). Install full heavy requirements from `requirements-heavy.txt` when you need to run full tests or debug OCR-related features.


### PR DESCRIPTION
Adds a short pointer in `doc_processor/CONTRIBUTING-NOTES.md` about `FAST_TEST_MODE` for running quick local tests without heavy binary deps, and notes where to install full heavy requirements for full test runs.