### PR TITLE
chore(tools): add preflight workflow and agent PR audit logging

### DIFF
--- a/.github/logs/.gitkeep
+++ b/.github/logs/.gitkeep
@@ -1,0 +1,1 @@
+# keep the logs directory

--- a/.github/workflows/preflight-check.yml
+++ b/.github/workflows/preflight-check.yml
@@ -1,0 +1,30 @@
+name: Preflight Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  preflight-validator:
+    name: Preflight Validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install PyYAML
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
+      - name: Run strict preflight validator
+        run: |
+          python3 tools/pr_preflight_validate.py --repo "${{ github.repository }}"

--- a/tools/create_pr_with_preflight.sh
+++ b/tools/create_pr_with_preflight.sh
@@ -82,6 +82,19 @@ if [[ -n "$COMMIT_MSG" ]]; then
   fi
 fi
 
+# Append an audit log entry to .github/logs/agent-pr-log.md so merged PRs include an audit trail
+mkdir -p .github/logs
+LOGFILE=.github/logs/agent-pr-log.md
+TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+COMMIT_SHA=$(git rev-parse --short HEAD || echo "-")
+cat >> "$LOGFILE" <<EOF
+- $TS | branch: $BRANCH | title: $TITLE | commit: $COMMIT_SHA
+EOF
+git add "$LOGFILE"
+if [[ -n "$(git status --porcelain)" ]]; then
+  git commit -m "chore: add agent PR audit entry for $BRANCH" || true
+fi
+
 echo "Pushing branch to origin..."
 git push -u origin "$BRANCH"
 


### PR DESCRIPTION
Adds a strict preflight GitHub Actions workflow that runs the Python preflight validator on PRs, and updates the PR creator to append an audit entry to .github/logs/agent-pr-log.md so PRs authored by the agent leave an audit trail. This is a metadata/tools change.\n\nJob name: 'Preflight Validator' (this will be added to branch-protection contexts after merge).